### PR TITLE
Marpa::XS is the stable release

### DIFF
--- a/lib/perlfaq4.pod
+++ b/lib/perlfaq4.pod
@@ -730,7 +730,7 @@ L<Regexp::Common::balanced> and L<Regexp::Common::delimited>).
 More complex cases will require to write a parser, probably
 using a parsing module from CPAN, like
 L<Regexp::Grammars>, L<Parse::RecDescent>, L<Parse::Yapp>, 
-L<Text::Balanced>, or L<Marpa>. 
+L<Text::Balanced>, or L<Marpa::XS>. 
 
 =head2 How do I reverse a string?
 


### PR DESCRIPTION
The reference to Marpa should be to its only stable release, Marpa::XS.  Thanks!
