### PR TITLE
Email::MIME requires encoding & charset

### DIFF
--- a/lib/perlfaq9.pod
+++ b/lib/perlfaq9.pod
@@ -293,7 +293,11 @@ Use the L<Email::MIME> and L<Email::Sender::Simple> modules, like so:
       To      => 'friend@example.com',
       Subject => 'Happy birthday!',
     ],
-    body_str => 'Happy birthday to you!',
+    attributes => {
+      encoding => 'quoted-printable',
+      charset  => 'ISO-8859-1',
+    },
+    body_str => "Happy birthday to you!\n",
   );
 
   use Email::Sender::Simple qw(sendmail);


### PR DESCRIPTION
The "How do I send email?" example does not work as written. You get the error "body_str was given, but no charset is defined at /usr/local/share/perl/5.10.1/Email/MIME.pm line 243". See [this question](http://stackoverflow.com/q/9254986/8355) on Stack Overflow.

Also, an email body should normally end with a newline.

This change was applied to the learn.perl.org example in perlorg/perlweb#35.
