### PR TITLE
perlglossary provided by Tom C. from Camel 4

### DIFF
--- a/lib/perlglossary.pod
+++ b/lib/perlglossary.pod
@@ -1,3442 +1,3634 @@
+
+=encoding utf8
+
 =head1 NAME
 
 perlglossary - Perl Glossary
 
 =head1 DESCRIPTION
 
-A glossary of terms (technical and otherwise) used in the Perl documentation.
-Other useful sources include the Free On-Line Dictionary of Computing
-L<http://foldoc.org/>, the Jargon File
-L<http://catb.org/~esr/jargon/>, and Wikipedia L<http://www.wikipedia.org/>.
+A glossary of terms (technical and otherwise) used in the Perl
+documentation, derived from the Glossary of the Glossary of I<Programming
+Perl>, Fourth Edition.  Words or phrases in bold are defined elsewhere in
+this glossary.
 
-=head2 A
+Other useful sources include the Unicode Glossary L<http://unicode.org/glossary/>,
+the Free On-Line Dictionary of Computing L<http://foldoc.org/>,
+the Jargon File L<http://catb.org/~esr/jargon/>,
+and Wikipedia L<http://www.wikipedia.org/>.
 
-=over 4
+=over
 
 =item accessor methods
 
-A L</method> used to indirectly inspect or update an L</object>'s
-state (its L<instance variables|/instance variable>).
+A B<X<accessor methods, defined>X<methods, accessor>method> used to
+indirectly inspect or update an B<object>’s state (its B<instance
+variables>).
 
 =item actual arguments
 
-The L<scalar values|/scalar value> that you supply to a L</function>
-or L</subroutine> when you call it.  For instance, when you call
-C<power("puff")>, the string C<"puff"> is the actual argument.  See
-also L</argument> and L</formal arguments>.
+The B<X<actual arguments>X<arguments, actual>scalar values> that you supply
+to a B<function> or B<subroutine> when you call it. For instance, when you
+call C<power("puff")>, the string C<"puff"> is the actual argument. See also
+B<argument> and B<formal arguments>.
 
 =item address operator
 
-Some languages work directly with the memory addresses of values, but
-this can be like playing with fire.  Perl provides a set of asbestos
-gloves for handling all memory management.  The closest to an address
-operator in Perl is the backslash operator, but it gives you a L</hard
-reference>, which is much safer than a memory address.
+Some X<address operator>languages work directly with the memory addresses of
+values, but this can be like playing with fire. Perl provides a set of
+asbestos gloves for handling all memory management. The closest to an
+address operator in Perl is the backslash operator, but it gives you a
+B<hard reference>, which is much safer than a memory address.
 
 =item algorithm
 
-A well-defined sequence of steps, clearly enough explained that even a
-computer could do them.
+A X<algorithms (term)>well-defined sequence of steps, explained clearly
+enough that even a computer could do them.
 
 =item alias
 
-A nickname for something, which behaves in all ways as though you'd
-used the original name instead of the nickname.  Temporary aliases are
-implicitly created in the loop variable for C<foreach> loops, in the
-C<$_> variable for L<map|perlfunc/map> or L<grep|perlfunc/grep>
-operators, in C<$a> and C<$b> during L<sort|perlfunc/sort>'s
-comparison function, and in each element of C<@_> for the L</actual
-arguments> of a subroutine call.  Permanent aliases are explicitly
-created in L<packages|/package> by L<importing|/import> symbols or by
-assignment to L<typeglobs|/typeglob>.  Lexically scoped aliases for
-package variables are explicitly created by the L<our|perlfunc/our>
-declaration.
+A X<aliases, defined>nickname for something, which behaves in all ways as
+though you’d used the original name instead of the nickname. Temporary
+aliases are implicitly created in the loop variable for C<foreach> loops, in
+the C<$_> variable for C<map> or C<grep> operators, in C<$a> and C<$b>
+during C<sort>’s comparison function, and in each element of C<@_> for the
+B<actual arguments> of a subroutine call. Permanent aliases are explicitly
+created in B<packages> by B<importing> symbols or by assignment to
+B<typeglobs>. Lexically scoped aliases for package variables are explicitly
+created by the C<our> declaration.
+
+=item alphabetic
+
+The X<alphabetic sort>sort of characters we put into words. In Unicode, this
+is all letters including all ideographs and certain diacritics, letter
+numbers like Roman numerals, and various combining marks.
 
 =item alternatives
 
-A list of possible choices from which you may select only one, as in
-"Would you like door A, B, or C?"  Alternatives in regular expressions
-are separated with a single vertical bar: C<|>.  Alternatives in
-normal Perl expressions are separated with a double vertical bar:
-C<||>.  Logical alternatives in L</Boolean> expressions are separated
+A X<alternative characters>list of possible choices from which you may
+select only one, as in, “Would you like door A, B, or C?” Alternatives in
+regular expressions are separated with a single vertical bar: C<|>.
+Alternatives in normal Perl expressions are separated with a double vertical
+bar: C<||>. Logical alternatives in B<Boolean> expressions are separated
 with either C<||> or C<or>.
 
 =item anonymous
 
-Used to describe a L</referent> that is not directly accessible
-through a named L</variable>.  Such a referent must be indirectly
-accessible through at least one L</hard reference>.  When the last
-hard reference goes away, the anonymous referent is destroyed without
-pity.
+Used to X<anonymous referents>X<referents, anonymous>describe a B<referent>
+that is not directly accessible through a named B<variable>. Such a referent
+must be indirectly accessible through at least one B<hard reference>. When
+the last hard reference goes away, the anonymous referent is destroyed
+without pity.
+
+=item application
+
+A X<applications (term)>bigger, fancier sort of B<program> with a fancier
+name so people don’t realize they are using a program.
 
 =item architecture
 
-The kind of computer you're working on, where one "kind" of computer
-means all those computers sharing a compatible machine language.
+The kind of X<architecture>computer you’re working on, where one “kind” of
+computer means all those computers sharing a compatible machine language.
 Since Perl programs are (typically) simple text files, not executable
-images, a Perl program is much less sensitive to the architecture it's
-running on than programs in other languages, such as C, that are
-compiled into machine code.  See also L</platform> and L</operating
-system>.
+images, a Perl program is much less sensitive to the architecture it’s
+running on than programs in other languages, such as C, that are B<compiled>
+into machine code. See also B<platform> and B<operating system>.
 
 =item argument
 
-A piece of data supplied to a L<program|/executable file>,
-L</subroutine>, L</function>, or L</method> to tell it what it's
-supposed to do.  Also called a "parameter".
+A X<arguments, defined>piece of data supplied to a B<program>,
+B<subroutine>, B<function>, or B<method> to tell it what it’s supposed to
+do. Also called a “parameter”.
 
 =item ARGV
 
-The name of the array containing the L</argument> L</vector> from the
-command line.  If you use the empty C<< E<lt>E<gt> >> operator, L</ARGV> is
-the name of both the L</filehandle> used to traverse the arguments and
-the L</scalar> containing the name of the current input file.
+The name of the X<ARGV filehandle>array containing the B<argument> B<vector>
+from the command line. If you use the empty C<E<lt>E<gt>> operator, C<ARGV>
+is the name of both the B<filehandle> used to traverse the arguments and the
+B<scalar> containing the name of the current input file.
 
 =item arithmetical operator
 
-A L</symbol> such as C<+> or C</> that tells Perl to do the arithmetic
-you were supposed to learn in grade school.
+A B<X<arithmetic operators, about>symbol> such as C<+> or C</> that tells
+Perl to do the arithmetic you were supposed to learn in grade school.
 
 =item array
 
-An ordered sequence of L<values|/value>, stored such that you can
-easily access any of the values using an integer L</subscript>
-that specifies the value's L</offset> in the sequence.
+An X<arrays, defined>ordered sequence of B<values>, stored such that you can
+easily access any of the values using an I<integer subscript> that specifies
+the value’s B<offset> in the sequence.
 
 =item array context
 
-An archaic expression for what is more correctly referred to as
-L</list context>.
+An archaic X<array context>expression for what is more correctly referred to
+as B<list context>.
+
+=item Artistic License
+
+The open X<Artistic License>source license that X<Wall, Larry>Larry Wall
+created for Perl, maximizing Perl’s usefulness, availability, and
+modifiability. The current version is 2. (L<http://www.opensource.org/licenses/artistic-license.php>).
 
 =item ASCII
 
-The American Standard Code for Information Interchange (a 7-bit
-character set adequate only for poorly representing English text).
-Often used loosely to describe the lowest 128 values of the various
-ISO-8859-X character sets, a bunch of mutually incompatible 8-bit
-codes sometimes described as half ASCII.  See also L</Unicode>.
+The X<ASCII (American Standard Code for Information Interchange)>X<American
+Standard Code for Information Interchange (ASCII)>American Standard Code for
+Information Interchange (a 7-bit character set adequate only for poorly
+representing English text). Often used loosely to describe the lowest 128
+values of the various ISO-8859-X character sets, a bunch of mutually
+incompatible 8-bit codes best described as half ASCII. See also B<Unicode>.
 
 =item assertion
 
-A component of a L</regular expression> that must be true for the
-pattern to match but does not necessarily match any characters itself.
-Often used specifically to mean a L</zero width> assertion.
+A X<assertions (in regexes), defined>X<regular expressions, assertions
+in>component of a B<regular expression> that must be true for the pattern to
+match but does not necessarily match any characters itself. Often used
+specifically to mean a B<zero-width> assertion.
 
 =item assignment
 
-An L</operator> whose assigned mission in life is to change the value
-of a L</variable>.
+An X<assignments, defined>B<operator> whose assigned mission in life is to
+change the value of a B<variable>.
 
 =item assignment operator
 
-Either a regular L</assignment>, or a compound L</operator> composed
-of an ordinary assignment and some other operator, that changes the
-value of a variable in place, that is, relative to its old value.  For
-example, C<$a += 2> adds C<2> to C<$a>.
+Either a X<assignment operators, about>regular B<assignment> or a compound
+B<operator> composed of an ordinary assignment and some other operator, that
+changes the value of a variable in place; that is, relative to its old
+value. For example, C<$a += 2> adds C<2> to C<$a>.
 
 =item associative array
 
-See L</hash>.  Please.
+See B<hash>. X<associative arrays>Please. The term associative array is the
+old Perl 4 term for a B<hash>. Some languages call it a dictionary.
 
 =item associativity
 
-Determines whether you do the left L</operator> first or the right
-L</operator> first when you have "A L</operator> B L</operator> C" and
-the two operators are of the same precedence.  Operators like C<+> are
-left associative, while operators like C<**> are right associative.
-See L<perlop> for a list of operators and their associativity.
+Determines X<associativity>whether you do the left B<operator> first or the
+right B<operator> first when you have “A B<operator> B B<operator> C”, and
+the two operators are of the same precedence. Operators like C<+> are left
+associative, while operators like C<**> are right associative. See Camel
+chapter 3, “Unary and Binary Operators” for a list of operators and their
+associativity.
 
 =item asynchronous
 
-Said of events or activities whose relative temporal ordering is
-indeterminate because too many things are going on at once.  Hence, an
-asynchronous event is one you didn't know when to expect.
+Said of X<asynchronous event processing>events or activities whose relative
+temporal ordering is indeterminate because too many things are going on at
+once. Hence, an asynchronous event is one you didn’t know when to expect.
 
 =item atom
 
-A L</regular expression> component potentially matching a
-L</substring> containing one or more characters and treated as an
-indivisible syntactic unit by any following L</quantifier>.  (Contrast
-with an L</assertion> that matches something of L</zero width> and may
-not be quantified.)
+A B<regular X<atoms>expression> component potentially matching a
+B<substring> containing one or more characters and treated as an indivisible
+syntactic unit by any following B<quantifier>. (Contrast with an
+B<assertion> that matches something of B<zero width> and may not be quantified.)
 
 =item atomic operation
 
-When Democritus gave the word "atom" to the indivisible bits of
-matter, he meant literally something that could not be cut: I<a->
-(not) + I<tomos> (cuttable).  An atomic operation is an action that
-can't be interrupted, not one forbidden in a nuclear-free zone.
+When X<atomic operation>Democritus gave the word “atom” to the indivisible
+bits of matter, he meant literally something that could not be cut: I<ἀ->
+(not) + I<-τομος> (cuttable). An atomic operation is an action that can’t be
+interrupted, not one forbidden in a nuclear-free zone.
 
 =item attribute
 
-A new feature that allows the declaration of L<variables|/variable>
-and L<subroutines|/subroutine> with modifiers as in C<sub foo : locked
-method>.  Also, another name for an L</instance variable> of an
-L</object>.
+A new X<attribute feature>feature that allows the declaration of
+B<variables> and B<subroutines> with modifiers, as in C<sub foo : locked
+method>. Also another name for an B<instance variable> of an B<object>.
 
 =item autogeneration
 
-A feature of L</operator overloading> of L<objects|/object>, whereby
-the behavior of certain L<operators|/operator> can be reasonably
-deduced using more fundamental operators.  This assumes that the
-overloaded operators will often have the same relationships as the
-regular operators.  See L<perlop>.
+A X<autogeneration, about>feature of B<operator overloading> of B<objects>,
+whereby the behavior of certain B<operators> can be reasonably deduced using
+more fundamental operators. This assumes that the overloaded operators will
+often have the same relationships as the regular operators. See Camel
+chapter 13, “Overloading”.
 
 =item autoincrement
 
-To add one to something automatically, hence the name of the C<++>
-operator.  To instead subtract one from something automatically is
-known as an "autodecrement".
+To X<autoincrement (term)>add one to something automatically, hence the name
+of the C<++> operator. To instead subtract one from something automatically
+is known as an “autodecrement”.
 
 =item autoload
 
-To load on demand.  (Also called "lazy" loading.)  Specifically, to
-call an L<AUTOLOAD|perlsub/Autoloading> subroutine on behalf of an
-undefined subroutine.
+To X<autoloading, defined>load on demand. (Also called “lazy” loading.)
+Specifically, to call an C<AUTOLOAD> subroutine on behalf of an undefined
+subroutine.
 
 =item autosplit
 
-To split a string automatically, as the B<-a> L</switch> does when
-running under B<-p> or B<-n> in order to emulate L</awk>.  (See also
-the L<AutoSplit> module, which has nothing to do with the B<-a>
-switch, but a lot to do with autoloading.)
+To X<autosplit (term)>split a string automatically, as the I<–a> B<switch>
+does when running under I<–p> or I<–n> in order to emulate B<awk>. (See also
+the C<AutoSplit>X<AutoSplit module> module, which has nothing to do with the
+C<–a> switch but a lot to do with autoloading.)
 
 =item autovivification
 
-A Greco-Roman word meaning "to bring oneself to life".  In Perl,
-storage locations (L<lvalues|/lvalue>) spontaneously generate
-themselves as needed, including the creation of any L</hard reference>
-values to point to the next level of storage.  The assignment
-C<$a[5][5][5][5][5] = "quintet"> potentially creates five scalar
-storage locations, plus four references (in the first four scalar
-locations) pointing to four new anonymous arrays (to hold the last
-four scalar locations).  But the point of autovivification is that you
-don't have to worry about it.
+A X<autovivification>Graeco-Roman word meaning “to bring oneself to life”.
+In Perl, storage locations (B<lvalues>) spontaneously generate themselves as
+needed, including the creation of any B<hard reference> values to point to
+the next level of storage. The assignment C<$a[5][5][5][5][5] = "quintet">
+potentially creates five scalar storage locations, plus four references (in
+the first four scalar locations) pointing to four new anonymous arrays (to
+hold the last four scalar locations). But the point of autovivification is
+that you don’t have to worry about it.
 
 =item AV
 
-Short for "array value", which refers to one of Perl's internal data
-types that holds an L</array>.  The L</AV> type is a subclass of
-L</SV>.
+Short X<AV (array value)>X<array value (AV)>X<values, array>for “array
+value”, which refers to one of Perl’s internal data types that holds an
+B<array>. The C<AV> type is a subclass of B<SV>.
 
 =item awk
 
-Descriptive editing term--short for "awkward".  Also coincidentally
-refers to a venerable text-processing language from which Perl derived
-some of its high-level ideas.
-
-=back
-
-=head2 B
-
-=over 4
+Descriptive X<awk (editing term)>editing term—short for “awkward”. Also
+coincidentally refers to a venerable text-processing language from which
+Perl derived some of its high-level ideas.
 
 =item backreference
 
-A substring L<captured|/capturing> by a subpattern within
-unadorned parentheses in a L</regex>, also referred to as a capture group.  The
-sequences (C<\g1>, C<\g2>, etc.)  later in the same pattern refer back to
-the corresponding subpattern in the current match.  Outside the pattern,
-the numbered variables (C<$1>, C<$2>, etc.) continue to refer to these
-same values, as long as the pattern was the last successful match of
-the current dynamic scope.  C<\g{-1}> can be used to refer to a group by
-relative rather than absolute position; and groups can be also be named, and
-referred to later by name rather than number.  See L<perlre/"Capture groups">.
+A X<backreferences, about>X<references, backreferences>substring B<captured>
+by a subpattern within unadorned parentheses in a B<regex>. Backslashed
+decimal numbers (C<\1>, C<\2>, etc.) later in the same pattern refer back to
+the corresponding subpattern in the current match. Outside the pattern, the
+numbered variables (C<$1>, C<$2>, etc.) continue to refer to these same
+values, as long as the pattern was the last successful match of the current
+B<dynamic scope>.
 
 =item backtracking
 
-The practice of saying, "If I had to do it all over, I'd do it
-differently," and then actually going back and doing it all over
-differently.  Mathematically speaking, it's returning from an
-unsuccessful recursion on a tree of possibilities.  Perl backtracks
-when it attempts to match patterns with a L</regular expression>, and
-its earlier attempts don't pan out.  See L<perlre/Backtracking>.
+The X<backtracking>practice of saying, “If I had to do it all over, I’d do
+it differently,” and then actually going back and doing it all over
+differently. Mathematically speaking, it’s returning from an unsuccessful
+recursion on a tree of possibilities. Perl backtracks when it attempts to
+match patterns with a B<regular expression>, and its earlier attempts don’t
+pan out. See the section “The Little Engine That /Couldn(n’t)” in Camel
+chapter 5, “Pattern Matching”.
 
 =item backward compatibility
 
-Means you can still run your old program because we didn't break any
-of the features or bugs it was relying on.
+Means X<backward compatibility, defined>you can still run your old program
+because we didn’t break any of the features or bugs it was relying on.
 
 =item bareword
 
-A word sufficiently ambiguous to be deemed illegal under L<use strict
-'subs'|strict/strict subs>.  In the absence of that stricture, a
-bareword is treated as if quotes were around it.
+A word X<barewords, about>sufficiently ambiguous to be deemed illegal under
+C<use strict 'subs'>. In the absence of that stricture, a bareword is
+treated as if quotes were around it.
 
 =item base class
 
-A generic L</object> type; that is, a L</class> from which other, more
-specific classes are derived genetically by L</inheritance>.  Also
-called a "superclass" by people who respect their ancestors.
+A X<base classes>X<classes, base>generic B<object> type; that is, a B<class>
+from which other, more specific classes are derived genetically by
+B<inheritance>. Also called aX<superclasses>X<classes, superclasses>
+“superclass” by people who respect their ancestors.
 
 =item big-endian
 
-From Swift: someone who eats eggs big end first.  Also used of
-computers that store the most significant L</byte> of a word at a
-lower byte address than the least significant byte.  Often considered
-superior to little-endian machines.  See also L</little-endian>.
+From X<big–endian, defined>X<endianness, big–endian>Swift: someone who
+eats eggs big end first. Also used of computers that store the most
+significant B<byte> of a word at a lower byte address than the least
+significant byte. Often considered superior to little-endian machines. See
+also B<little-endian>.
 
 =item binary
 
-Having to do with numbers represented in base 2.  That means there's
-basically two numbers, 0 and 1.  Also used to describe a "non-text
-file", presumably because such a file makes full use of all the binary
-bits in its bytes.  With the advent of L</Unicode>, this distinction,
-already suspect, loses even more of its meaning.
+Having X<binary (term)>to do with numbers represented in base 2. That means
+there’s basically two numbers: 0 and 1. Also used to describe a file of
+“nontext”, presumably because such a file makes full use of all the binary
+bits in its bytes. With the advent of B<Unicode>, this distinction, already
+suspect, loses even more of its meaning.
 
 =item binary operator
 
-An L</operator> that takes two L<operands|/operand>.
+An B<X<binary operators, about>operator> that takes two B<operands>.
 
 =item bind
 
-To assign a specific L</network address> to a L</socket>.
+To X<bind (term)>assign a specific B<network address> to a B<socket>.
 
 =item bit
 
-An integer in the range from 0 to 1, inclusive.  The smallest possible
-unit of information storage.  An eighth of a L</byte> or of a dollar.
-(The term "Pieces of Eight" comes from being able to split the old
-Spanish dollar into 8 bits, each of which still counted for money.
-That's why a 25-cent piece today is still "two bits".)
+An X<bits, defined>integer in the range from 0 to 1, inclusive. The smallest
+possible unit of information storage. An eighth of a B<byte> or of a dollar.
+(The term “Pieces of Eight” comes from being able to split the old Spanish
+dollar into 8 bits, each of which still counted for money. That’s why a 25-
+cent piece today is still “two bits”.)
 
 =item bit shift
 
-The movement of bits left or right in a computer word, which has the
-effect of multiplying or dividing by a power of 2.
+The X<bit–shift operators, defined>movement of bits left or right in a
+computer word, which has the effect of multiplying or dividing by a
+power of 2.
 
 =item bit string
 
-A sequence of L<bits|/bit> that is actually being thought of as a
+A X<bit string>sequence of B<bits> that is actually being thought of as a
 sequence of bits, for once.
 
 =item bless
 
-In corporate life, to grant official approval to a thing, as in, "The
-VP of Engineering has blessed our WebCruncher project." Similarly in
-Perl, to grant official approval to a L</referent> so that it can
-function as an L</object>, such as a WebCruncher object.  See
-L<perlfunc/"bless">.
+In X<bless function, about>X<bless (term)>corporate life, to grant official
+approval to a thing, as in, “The VP of Engineering has blessed our
+WebCruncher project.” Similarly, in Perl, to grant official approval to a
+B<referent> so that it can function as an B<object>, such as a WebCruncher
+object. See the C<bless> function in Camel chapter 27, “Functions”.
 
 =item block
 
-What a L</process> does when it has to wait for something: "My process
-blocked waiting for the disk."  As an unrelated noun, it refers to a
-large chunk of data, of a size that the L</operating system> likes to
-deal with (normally a power of two such as 512 or 8192).  Typically
-refers to a chunk of data that's coming from or going to a disk file.
+What X<blocks, defined>a B<process> does when it has to wait for something:
+“My process blocked waiting for the disk.” As an unrelated noun, it refers
+to a large chunk of data, of a size that the B<operating system> likes to
+deal with (normally a power of 2 such as 512 or 8192). Typically refers to
+a chunk of data that’s coming from or going to a disk file.
 
 =item BLOCK
 
-A syntactic construct consisting of a sequence of Perl
-L<statements|/statement> that is delimited by braces.  The C<if> and
-C<while> statements are defined in terms of L<BLOCKs|/BLOCK>, for instance.
-Sometimes we also say "block" to mean a lexical scope; that is, a
-sequence of statements that act like a L</BLOCK>, such as within an
-L<eval|perlfunc/eval> or a file, even though the statements aren't
-delimited by braces.
+A X<BLOCK construct, about>X<constructs, BLOCK>syntactic construct
+consisting of a sequence of Perl B<statements> that is delimited by braces.
+The C<if> and C<while> statements are defined in terms of I<C<BLOCK>>s, for
+instance. Sometimes we also say “block” to mean a lexical scope; that is, a
+sequence of statements that acts like a I<C<BLOCK>>, such as within an
+C<eval> or a file, even though the statements aren’t delimited by braces.
 
 =item block buffering
 
-A method of making input and output efficient by passing one L</block>
-at a time.  By default, Perl does block buffering to disk files.  See
-L</buffer> and L</command buffering>.
+A X<block buffering>X<buffering, block>method of making input and output
+efficient by passing one B<block> at a time. By default, Perl does block
+buffering to disk files. See B<buffer> and B<command buffering>.
 
 =item Boolean
 
-A value that is either L</true> or L</false>.
+A X<Boolean values>X<values, Boolean>value that is either B<true> or
+B<false>.
 
 =item Boolean context
 
-A special kind of L</scalar context> used in conditionals to decide
-whether the L</scalar value> returned by an expression is L</true> or
-L</false>.  Does not evaluate as either a string or a number.  See
-L</context>.
+A X<Boolean context, about>X<context, Boolean>special kind of B<scalar
+context> used in conditionals to decide whether the B<scalar value> returned
+by an expression is B<true> or B<false>. Does not evaluate as either a
+string or a number. See B<context>.
 
 =item breakpoint
 
-A spot in your program where you've told the debugger to stop
-L<execution|/execute> so you can poke around and see whether anything
-is wrong yet.
+A X<breakpoints, defined>spot in your program where you’ve told the debugger
+to stop B<execution> so you can poke around and see whether anything is
+wrong yet.
 
 =item broadcast
 
-To send a L</datagram> to multiple destinations simultaneously.
+To X<broadcast (networking term)>send a B<datagram> to multiple destinations
+simultaneously.
 
 =item BSD
 
-A psychoactive drug, popular in the 80s, probably developed at
-U. C. Berkeley or thereabouts.  Similar in many ways to the
-prescription-only medication called "System V", but infinitely more
-useful.  (Or, at least, more fun.)  The full chemical name is
-"Berkeley Standard Distribution".
+A X<BSD (Berkeley Standard Distribution)>X<Berkeley Standard Distribution
+(BSD)>psychoactive drug, popular in the ’80s, probably developed at UC
+Berkeley or thereabouts. Similar in many ways to the prescription-only
+medication called “System V”, but infinitely more useful. (Or, at least,
+more fun.) The full chemical name is “Berkeley Standard Distribution”.
 
 =item bucket
 
-A location in a L</hash table> containing (potentially) multiple
-entries whose keys "hash" to the same hash value according to its hash
-function.  (As internal policy, you don't have to worry about it,
-unless you're into internals, or policy.)
+A X<buckets (term)>location in a B<hash table> containing (potentially)
+multiple entries whose keys “hash” to the same hash value according to its
+hash function. (As internal policy, you don’t have to worry about it unless
+you’re into internals, or policy.)
 
 =item buffer
 
-A temporary holding location for data.  L<Block buffering|/block
-buffering> means that the data is passed on to its destination
-whenever the buffer is full.  L<Line buffering|/line buffering> means
-that it's passed on whenever a complete line is received.  L<Command
-buffering|/command buffering> means that it's passed every time you do
-a L<print|perlfunc/print> command (or equivalent).  If your output is
-unbuffered, the system processes it one byte at a time without the use
-of a holding area.  This can be rather inefficient.
+A X<buffers, defined>temporary holding location for data. Data that are
+B<Block buffering> means that the data is passed on to its destination
+whenever the buffer is full. B<Line buffering> means that it’s passed on
+whenever a complete line is received. B<Command buffering> means that it’s
+passed every time you do a C<print> command (or equivalent). If your output
+is unbuffered, the system processes it one byte at a time without the use of
+a holding area. This can be rather inefficient.
 
 =item built-in
 
-A L</function> that is predefined in the language.  Even when hidden
-by L</overriding>, you can always get at a built-in function by
-L<qualifying|/qualified> its name with the C<CORE::> pseudo-package.
+A B<X<built–in functions, about>function> that is predefined in the
+language. Even when hidden by B<overriding>, you can always get at a built-
+in function by B<qualifying> its name with the C<CORE::> pseudopackage.
 
 =item bundle
 
-A group of related modules on L</CPAN>.  (Also, sometimes refers to a
-group of command-line switches grouped into one L</switch cluster>.)
+A X<bundles (term)>group of related modules on B<CPAN>. (Also sometimes
+refers to a group of command-line switches grouped into one B<switch
+cluster>.)
 
 =item byte
 
-A piece of data worth eight L<bits|/bit> in most places.
+A X<bytes (term)>piece of data worth eight B<bits> in most places.
 
 =item bytecode
 
-A pidgin-like language spoken among 'droids when they don't wish to
-reveal their orientation (see L</endian>).  Named after some similar
-languages spoken (for similar reasons) between compilers and
-interpreters in the late 20th century.  These languages are
-characterized by representing everything as a
-non-architecture-dependent sequence of bytes.
-
-=back
-
-=head2 C
-
-=over 4
+A pidgin-like lingo spoken among ’droids when they don’t wish to reveal
+their orientation (see B<endian>). Named after some similar languages spoken
+(for similar reasons) between compilers and interpreters in the late 20ᵗʰ
+century. These languages are characterized by representing everything as a
+nonarchitecture-dependent sequence of bytes.
 
 =item C
 
-A language beloved by many for its inside-out L</type> definitions,
-inscrutable L</precedence> rules, and heavy L</overloading> of the
-function-call mechanism.  (Well, actually, people first switched to C
-because they found lowercase identifiers easier to read than upper.)
-Perl is written in C, so it's not surprising that Perl borrowed a few
-ideas from it.
+A X<C language, about>language beloved by many for its inside-out B<type>
+definitions, inscrutable B<precedence> rules, and heavy B<overloading> of
+the function-call mechanism. (Well, actually, people first switched to C
+because they found lowercase identifiers easier to read than upper.) Perl is
+written in C, so it’s not surprising that Perl borrowed a few ideas from it.
 
-=item C preprocessor
+=item cache
 
-The typical C compiler's first pass, which processes lines beginning
-with C<#> for conditional compilation and macro definition and does
-various manipulations of the program text based on the current
-definitions.  Also known as I<cpp>(1).
-
-=item call by reference
-
-An L</argument>-passing mechanism in which the L</formal arguments>
-refer directly to the L</actual arguments>, and the L</subroutine> can
-change the actual arguments by changing the formal arguments.  That
-is, the formal argument is an L</alias> for the actual argument.  See
-also L</call by value>.
-
-=item call by value
-
-An L</argument>-passing mechanism in which the L</formal arguments>
-refer to a copy of the L</actual arguments>, and the L</subroutine>
-cannot change the actual arguments by changing the formal arguments.
-See also L</call by reference>.
+A X<cache (term)>data repository. Instead of computing expensive answers
+several times, compute it once and save the result.
 
 =item callback
 
-A L</handler> that you register with some other part of your program
-in the hope that the other part of your program will L</trigger> your
+A B<X<callbacks>handler> that you register with some other part of your
+program in the hope that the other part of your program will B<trigger> your
 handler when some event of interest transpires.
+
+=item call by reference
+
+An B<argument>-passing X<call by reference>X<references, call by reference
+mechanism>mechanism in which the B<formal arguments> refer directly to the
+B<actual arguments>, and the B<subroutine> can change the actual arguments
+by changing the formal arguments. That is, the formal argument is an
+B<alias> for the actual argument. See also B<call by value>.
+
+=item call by value
+
+An B<X<call by value>argument>-passing mechanism in which the B<formal
+arguments> refer to a copy of the B<actual arguments>, and the
+B<subroutine> cannot change the actual arguments by changing the formal
+arguments. See also B<call by reference>.
 
 =item canonical
 
-Reduced to a standard form to facilitate comparison.
+Reduced X<canonical (term)>to a standard form to facilitate comparison.
 
-=item capture buffer, capture group
+=item capture variables
 
-These two terms are synonymous:
-a L<captured substring|/capturing> by a regex subpattern.
+The X<capture variables>X<variables, capture>variables—such as C<$1> and
+C<$2>, and C<%+> and C<%– >—that hold the text remembered in a pattern
+match. See Camel chapter 5, “Pattern Matching”.
 
 =item capturing
 
-The use of parentheses around a L</subpattern> in a L</regular
-expression> to store the matched L</substring> as a L</backreference>
-or L<capture group|/capture buffer, capture group>.
-(Captured strings are also returned as a list in L</list context>.)
+The X<capturing in pattern matching>X<subpatterns, capturing>X<pattern
+matching, capturing in>use of parentheses around a B<subpattern> in a
+B<regular expression> to store the matched B<substring> as a
+B<backreference>. (Captured strings are also returned as a list in B<list
+context>.) See Camel chapter 5, “Pattern Matching”.
+
+=item cargo cult
+
+Copying X<cargo cult>and pasting code without understanding it, while
+superstitiously believing in its value. This term originated from
+preindustrial cultures dealing with the detritus of explorers and colonizers
+of technologically advanced cultures. See I<The Gods Must Be Crazy>.
+
+=item case
+
+A X<case (character)>X<characters, case considerations>property of certain
+characters. Originally, typesetter stored capital letters in the upper of
+two cases and small letters in the lower one. Unicode recognizes three
+cases: B<lowercase> (B<character property> C<\p{lower}>), B<titlecase>
+(C<\p{title}>), and B<uppercase> (C<\p{upper}>). A fourth casemapping called
+B<foldcase> is not itself a distinct case, but it is used internally to
+implement B<casefolding>. Not all letters have case, and some nonletters
+have case.
+
+=item casefolding
+
+Comparing X<casefolding>or matching a string case-insensitively. In Perl, it
+is implemented with the C</i> pattern modifier, the C<fc> function, and the
+C<\F> double-quote translation escape.
+
+=item casemapping
+
+The X<casemapping>process of converting a string to one of the four Unicode
+B<casemaps>; in Perl, it is implemented with the C<fc>, C<lc>, C<ucfirst>,
+and C<uc> functions.
 
 =item character
 
-A small integer representative of a unit of orthography.
-Historically, characters were usually stored as fixed-width integers
-(typically in a byte, or maybe two, depending on the character set),
-but with the advent of UTF-8, characters are often stored in a
-variable number of bytes depending on the size of the integer that
-represents the character.  Perl manages this transparently for you,
-for the most part.
+The X<characters, defined>smallest individual element of a string. Computers
+store characters as integers, but Perl lets you operate on them as text. The
+integer used to represent a particular character is called that character’s
+B<codepoint>.
 
 =item character class
 
-A square-bracketed list of characters used in a L</regular expression>
-to indicate that any character of the set may occur at a given point.
-Loosely, any predefined set of characters so used.
+A X<character classes, about>X<classes, character>square-bracketed list of
+characters used in a B<regular expression> to indicate that any character
+of the set may occur at a given point. Loosely, any predefined set of
+characters so used.
 
 =item character property
 
-A predefined L</character class> matchable by the C<\p>
-L</metasymbol>.  Many standard properties are defined for L</Unicode>.
+A X<character property>predefined B<character class> matchable by the C<\p>
+or C<\P> B<metasymbol>. B<Unicode> defines hundreds of standard properties
+for every possible codepoint, and Perl defines a few of its own, too.
 
 =item circumfix operator
 
-An L</operator> that surrounds its L</operand>, like the angle
-operator, or parentheses, or a hug.
+An X<circumfix operator>B<operator> that surrounds its B<operand>, like the
+angle operator, or parentheses, or a hug.
 
 =item class
 
-A user-defined L</type>, implemented in Perl via a L</package> that
-provides (either directly or by inheritance) L<methods|/method> (that
-is, L<subroutines|/subroutine>) to handle L<instances|/instance> of
-the class (its L<objects|/object>).  See also L</inheritance>.
+A X<classes, defined>user-defined B<type>, implemented in Perl via a
+B<package> that provides (either directly or by inheritance) B<methods>
+(that is, B<subroutines>) to handle B<instances> of the class (its
+B<objects>). See also B<inheritance>.
 
 =item class method
 
-A L</method> whose L</invocant> is a L</package> name, not an
-L</object> reference.  A method associated with the class as a whole.
+A B<X<class methods>X<methods, class>method> whose B<invocant> is a
+B<package> name, not an B<object> reference. A method associated with the
+class as a whole. Also see B<instance method>.
 
 =item client
 
-In networking, a L</process> that initiates contact with a L</server>
-process in order to exchange data and perhaps receive a service.
-
-=item cloister
-
-A L</cluster> used to restrict the scope of a L</regular expression
-modifier>.
+In X<clients, defined>X<processes, client>networking, a B<process> that
+initiates contact with a B<server> process in order to exchange data and
+perhaps receive a service.
 
 =item closure
 
-An L</anonymous> subroutine that, when a reference to it is generated
-at run time, keeps track of the identities of externally visible
-L<lexical variables|/lexical variable> even after those lexical
-variables have supposedly gone out of L</scope>.  They're called
-"closures" because this sort of behavior gives mathematicians a sense
-of closure.
+An B<X<closure subroutines>X<subroutines, closure>anonymous> subroutine
+that, when a reference to it is generated at runtime, keeps track of the
+identities of externally visible B<lexical variables>, even after those
+lexical variables have supposedly gone out of B<scope>. They’re called
+“closures” because this sort of behavior gives mathematicians a sense of
+closure.
 
 =item cluster
 
-A parenthesized L</subpattern> used to group parts of a L</regular
-expression> into a single L</atom>.
+A X<clusters, defined>X<subpatterns, cluster>parenthesized B<subpattern>
+used to group parts of a B<regular expression> into a single B<atom>.
 
 =item CODE
 
-The word returned by the L<ref|perlfunc/ref> function when you apply
-it to a reference to a subroutine.  See also L</CV>.
+The X<CODE (ref function)>X<ref function, about>word returned by the C<ref>
+function when you apply it to a reference to a subroutine. See also B<CV>.
 
 =item code generator
 
-A system that writes code for you in a low-level language, such as
-code to implement the backend of a compiler.  See L</program
+A X<code generators, defined>system that writes code for you in a low-level
+language, such as code to implement the backend of a compiler. See B<program
 generator>.
 
-=item code point
+=item codepoint
 
-The position of a character in a character set encoding.  The character
-C<NULL> is almost certainly at the zeroth position in all character
-sets, so its code point is 0.  The code point for the C<SPACE>
-character in the ASCII character set is 0x20, or 32 decimal; in EBCDIC
-it is 0x40, or 64 decimal.  The L<ord|perlfunc/ord> function returns
-the code point of a character.
-
-"code position" and "ordinal" mean the same thing as "code point".
+The X<codepoints, about>integer a computer uses to represent a given
+character. ASCII codepoints are in the range 0 to 127; Unicode codepoints
+are in the range 0 to 0x1F_FFFF; and Perl codepoints are in the range 0 to
+2³²−1 or 0 to 2⁶⁴−1, depending on your native integer size. In Perl Culture,
+sometimes called B<ordinals>.
 
 =item code subpattern
 
-A L</regular expression> subpattern whose real purpose is to execute
-some Perl code, for example, the C<(?{...})> and C<(??{...})>
-subpatterns.
+A B<X<code subpatterns>X<subpatterns, code>regular expression> subpattern
+whose real purpose is to execute some Perl code—for example, the C<(?{...})>
+and C<(??{...})> subpatterns.
 
 =item collating sequence
 
-The order into which L<characters|/character> sort.  This is used by
-L</string> comparison routines to decide, for example, where in this
-glossary to put "collating sequence".
+The X<collating sequence>X<collating sequence>order into which B<characters>
+sort. This is used by B<string> comparison routines to decide, for example,
+where in this glossary to put “collating sequence”.
+
+=item co-maintainer
+
+A X<co–maintainers>person with permissions to index a B<namespace> in
+B<PAUSE>. Anyone can upload any namespace, but only primary and
+co-maintainers get their contributions indexed.
+
+=item combining character
+
+Any X<combining characters>X<characters, combining>character with the
+General Category of Combining Mark (C<\p{GC=M}>), which may be spacing or
+nonspacing. Some are even invisible. A sequence of combining characters
+following a grapheme base character together make up a single user-visible
+character called a B<grapheme>. Most but not all diacritics are combining
+characters, and vice versa.
 
 =item command
 
-In L</shell> programming, the syntactic combination of a program name
-and its arguments.  More loosely, anything you type to a shell (a
-command interpreter) that starts it doing something.  Even more
-loosely, a Perl L</statement>, which might start with a L</label> and
-typically ends with a semicolon.
+In B<shell> X<commands, defined>programming, the syntactic combination of a
+program name and its arguments. More loosely, anything you type to a shell
+(a command interpreter) that starts it doing something. Even more loosely, a
+Perl B<statement>, which might start with a B<label> and typically ends with
+a semicolon.
 
 =item command buffering
 
-A mechanism in Perl that lets you store up the output of each Perl
-L</command> and then flush it out as a single request to the
-L</operating system>.  It's enabled by setting the C<$|>
-(C<$AUTOFLUSH>) variable to a true value.  It's used when you don't
-want data sitting around not going where it's supposed to, which may
-happen because the default on a L</file> or L</pipe> is to use
-L</block buffering>.
-
-=item command name
-
-The name of the program currently executing, as typed on the command
-line.  In C, the L</command> name is passed to the program as the
-first command-line argument.  In Perl, it comes in separately as
-C<$0>.
+A X<command buffering>X<buffering, command>mechanism in Perl that lets you
+store up the output of each Perl B<command> and then flush it out as a
+single request to the B<operating system>. It’s enabled by setting the C<$|>
+(C<$AUTOFLUSH>) variable to a true value. It’s used when you don’t want data
+sitting around, not going where it’s supposed to, which may happen because
+the default on a B<file> or B<pipe> is to use B<block buffering>.
 
 =item command-line arguments
 
-The L<values|/value> you supply along with a program name when you
-tell a L</shell> to execute a L</command>.  These values are passed to
-a Perl program through C<@ARGV>.
+The X<command–line arguments>B<X<arguments, command–line>values> you supply
+along with a program name when you tell a B<shell> to execute a B<command>.
+These values are passed to a Perl program through C<@ARGV>.
+
+=item command name
+
+The X<command names>name of the program currently executing, as typed on the
+command line. In C, the B<command> name is passed to the program as the
+first command-line argument. In Perl, it comes in separately as C<$0>.
 
 =item comment
 
-A remark that doesn't affect the meaning of the program.  In Perl, a
-comment is introduced by a C<#> character and continues to the end of
-the line.
+A X<comments, defined>remark that doesn’t affect the meaning of the program.
+In Perl, a comment is introduced by a C<#> character and continues to the
+end of the line.
 
 =item compilation unit
 
-The L</file> (or L</string>, in the case of L<eval|perlfunc/eval>)
-that is currently being compiled.
+The X<compilation units>B<file> (or B<string>, in the case of C<eval>) that
+is currently being B<compiled>.
+
+=item compile
+
+The process of turning source code into a machine-usable form. See B<compile
+phase>.
 
 =item compile phase
 
-Any time before Perl starts running your main program.  See also
-L</run phase>.  Compile phase is mostly spent in L</compile time>, but
-may also be spent in L</run time> when C<BEGIN> blocks,
-L<use|perlfunc/use> declarations, or constant subexpressions are being
-evaluated.  The startup and import code of any L<use|perlfunc/use>
-declaration is also run during compile phase.
-
-=item compile time
-
-The time when Perl is trying to make sense of your code, as opposed to
-when it thinks it knows what your code means and is merely trying to
-do what it thinks your code says to do, which is L</run time>.
+Any X<compile phase, defined>time before Perl starts running your main
+program. See also B<run phase>. Compile phase is mostly spent in B<compile
+time>, but may also be spent in B<runtime> when C<BEGIN> blocks, C<use> or
+C<no> declarations, or constant subexpressions are being evaluated. The
+startup and import code of any C<use> declaration is also run during
+compile phase.
 
 =item compiler
 
-Strictly speaking, a program that munches up another program and spits
-out yet another file containing the program in a "more executable"
-form, typically containing native machine instructions.  The I<perl>
-program is not a compiler by this definition, but it does contain a
-kind of compiler that takes a program and turns it into a more
-executable form (L<syntax trees|/syntax tree>) within the I<perl>
-process itself, which the L</interpreter> then interprets.  There are,
-however, extension L<modules|/module> to get Perl to act more like a
-"real" compiler.  See L<O>.
+Strictly X<compilers and compiling, about>speaking, a program that munches
+up another program and spits out yet another file containing the program in
+a “more executable” form, typically containing native machine instructions.
+The I<perl> program is not a compiler by this definition, but it does
+contain a kind of compiler that takes a program and turns it into a more
+executable form (B<syntax trees>) within the I<perl> process itself, which
+the B<interpreter> then interprets. There are, however, extension B<modules>
+to get Perl to act more like a “real” compiler. See Camel chapter 16,
+“Compiling”.
+
+=item compile time
+
+The X<compile time, defined>time when Perl is trying to make sense of your
+code, as opposed to when it thinks it knows what your code means and is
+merely trying to do what it thinks your code says to do, which is B<runtime>.
 
 =item composer
 
-A "constructor" for a L</referent> that isn't really an L</object>,
-like an anonymous array or a hash (or a sonata, for that matter).  For
-example, a pair of braces acts as a composer for a hash, and a pair of
-brackets acts as a composer for an array.  See L<perlref/Making
-References>.
+A “constructor” X<composers, about>for a B<referent> that isn’t really an
+B<object>, like an anonymous array or a hash (or a sonata, for that matter).
+For example, a pair of braces acts as a composer for a hash, and a pair of
+brackets acts as a composer for an array. See the section “Creating
+References” in Camel chapter 8, “References”.
 
 =item concatenation
 
-The process of gluing one cat's nose to another cat's tail.  Also, a
-similar operation on two L<strings|/string>.
+The X<concatenating strings>X<strings, concatenating>process of gluing one
+cat’s nose to another cat’s tail. Also a similar operation on two
+B<strings>.
 
 =item conditional
 
-Something "iffy".  See L</Boolean context>.
+SomethingX<conditional (term)> “iffy”. See B<Boolean context>.
 
 =item connection
 
-In telephony, the temporary electrical circuit between the caller's
-and the callee's phone.  In networking, the same kind of temporary
-circuit between a L</client> and a L</server>.
+In X<connections (term)>telephony, the temporary electrical circuit between
+the caller’s and the callee’s phone. In networking, the same kind of
+temporary circuit between a B<client> and a B<server>.
 
 =item construct
 
-As a noun, a piece of syntax made up of smaller pieces.  As a
-transitive verb, to create an L</object> using a L</constructor>.
+As a X<constructs, defined>noun, a piece of syntax made up of smaller
+pieces. As a transitive verb, to create an B<object> using a B<constructor>.
 
 =item constructor
 
-Any L</class method>, instance L</method>, or L</subroutine>
-that composes, initializes, blesses, and returns an L</object>.
-Sometimes we use the term loosely to mean a L</composer>.
+AnyX<constructors, defined> B<class method>, B<instance>, or B<subroutine>
+that composes, initializes, blesses, and returns an B<object>. Sometimes we
+use the term loosely to mean a B<composer>.
 
 =item context
 
-The surroundings, or environment.  The context given by the
-surrounding code determines what kind of data a particular
-L</expression> is expected to return.  The three primary contexts are
-L</list context>, L</scalar context>, and L</void context>.  Scalar
-context is sometimes subdivided into L</Boolean context>, L</numeric
-context>, L</string context>, and L</void context>.  There's also a
-"don't care" scalar context (which is dealt with in Programming Perl,
-Third Edition, Chapter 2, "Bits and Pieces" if you care).
+The X<context, about>surroundings or environment. The context given by the
+surrounding code determines what kind of data a particular B<expression> is
+expected to return. The three primary contexts are B<list context>,
+B<scalar>, and B<void context>. Scalar context is sometimes subdivided into
+B<Boolean context>, B<numeric context>, B<string context>, and B<void
+context>. There’s also a “don’t care” context (which is dealt with in Camel
+chapter 2, “Bits and Pieces”, if you care).
 
 =item continuation
 
-The treatment of more than one physical L</line> as a single logical
-line.  L</Makefile> lines are continued by putting a backslash before
-the L</newline>.  Mail headers as defined by RFC 822 are continued by
-putting a space or tab I<after> the newline.  In general, lines in
-Perl do not need any form of continuation mark, because L</whitespace>
-(including newlines) is gleefully ignored.  Usually.
+The X<continuation lines>treatment of more than one physical B<line> as a
+single logical line. B<Makefile> lines are continued by putting a backslash
+before the B<newline>. Mail headers, as defined by X<RFC 822>RFC 822, are
+continued by putting a space or tab I<after> the newline. In general, lines
+in Perl do not need any form of continuation mark, because B<whitespace>
+(including newlines) is gleefully ignored. Usually.
 
 =item core dump
 
-The corpse of a L</process>, in the form of a file left in the
-L</working directory> of the process, usually as a result of certain
-kinds of fatal error.
+The X<core dump>corpse of a B<process>, in the form of a file left in the
+B<working directory> of the process, usually as a result of certain kinds
+of fatal errors.
 
 =item CPAN
 
-The Comprehensive Perl Archive Network.  (See L<perlfaq2/What modules and extensions are available for Perl?  What is CPAN?>).
+The X<Comprehensive Perl Archive Network>X<CPAN (Comprehensive Perl Archive
+Network), about>Comprehensive Perl Archive Network. (See the Camel Preface
+and Camel chapter 19, “CPAN” for details.)
+
+=item C preprocessor
+
+The X<C preprocessor>typical C compiler’s first pass, which processes lines
+beginning with C<#> for conditional compilation and macro definition, and
+does various manipulations of the program text based on the current
+definitions. Also known as I<cpp>(1).
 
 =item cracker
 
-Someone who breaks security on computer systems.  A cracker may be a
-true L</hacker> or only a L</script kiddie>.
-
-=item current package
-
-The L</package> in which the current statement is compiled.  Scan
-backwards in the text of your program through the current L<lexical
-scope|/lexical scoping> or any enclosing lexical scopes till you find
-a package declaration.  That's your current package name.
-
-=item current working directory
-
-See L</working directory>.
+Someone X<crackers>who breaks security on computer systems. A cracker may
+be a true B<hacker> or only a B<script kiddie>.
 
 =item currently selected output channel
 
-The last L</filehandle> that was designated with
-L<select|perlfunc/select>(C<FILEHANDLE>); L</STDOUT>, if no filehandle
-has been selected.
+The X<currently selected output channel>last B<filehandle> that was
+designated with C<select(FILEHANDLE)>; C<STDOUT>, if no filehandle has
+been selected.
+
+=item current package
+
+The B<package> X<current package>in which the current statement is
+B<compiled>. Scan backward in the text of your program through the current
+B<lexical scope> or any enclosing lexical scopes until you find a package
+declaration. That’s your current package name.
+
+=item current working directory
+
+SeeX<current working directory> B<working directory>.
 
 =item CV
 
-An internal "code value" typedef, holding a L</subroutine>.  The L</CV>
-type is a subclass of L</SV>.
-
-=back
-
-=head2 D
-
-=over 4
+In academia, a curriculum vitæ, a fancy kind of résumé. In Perl, an X<CV
+(code value)>X<code value (CV)>internal “code value” typedef holding a
+B<subroutine>. The C<CV> type is a subclass of B<SV>.
 
 =item dangling statement
 
-A bare, single L</statement>, without any braces, hanging off an C<if>
-or C<while> conditional.  C allows them.  Perl doesn't.
-
-=item data structure
-
-How your various pieces of data relate to each other and what shape
-they make when you put them all together, as in a rectangular table or
-a triangular-shaped tree.
-
-=item data type
-
-A set of possible values, together with all the operations that know
-how to deal with those values.  For example, a numeric data type has a
-certain set of numbers that you can work with and various mathematical
-operations that you can do on the numbers but would make little sense
-on, say, a string such as C<"Kilroy">.  Strings have their own
-operations, such as L</concatenation>.  Compound types made of a
-number of smaller pieces generally have operations to compose and
-decompose them, and perhaps to rearrange them.  L<Objects|/object>
-that model things in the real world often have operations that
-correspond to real activities.  For instance, if you model an
-elevator, your elevator object might have an C<open_door()>
-L</method>.
+A bare, single B<X<dangling statements>X<statements, dangling>statement>,
+without any braces, hanging off an C<if> or C<while> conditional. C allows
+them. Perl doesn’t.
 
 =item datagram
 
-A packet of data, such as a L</UDP> message, that (from the viewpoint
-of the programs involved) can be sent independently over the network.
-(In fact, all packets are sent independently at the L</IP> level, but
-L</stream> protocols such as L</TCP> hide this from your program.)
+A packet of X<datagrams, defined>data, such as a B<UDP> message, that (from
+the viewpoint of the programs involved) can be sent independently over the
+network. (In fact, all packets are sent independently at the B<IP> level,
+but B<stream> protocols such as B<TCP> hide this from your program.)
+
+=item data structure
+
+How your X<data structures, defined>various pieces of data relate to each
+other and what shape they make when you put them all together, as in a
+rectangular table or a triangular tree.
+
+=item data type
+
+A set of X<data types, defined>possible values, together with all the
+operations that know how to deal with those values. For example, a numeric
+data type has a certain set of numbers that you can work with, as well as
+various mathematical operations that you can do on the numbers, but would
+make little sense on, say, a string such as C<"Kilroy">. Strings have their
+own operations, such as B<concatenation>. Compound types made of a number of
+smaller pieces generally have operations to compose and decompose them, and
+perhaps to rearrange them. B<Objects> that model things in the real world
+often have operations that correspond to real activities. For instance, if
+you model an elevator, your elevator object might have an C<open_door>
+B<method>.
 
 =item DBM
 
-Stands for "Data Base Management" routines, a set of routines that
-emulate an L</associative array> using disk files.  The routines use a
-dynamic hashing scheme to locate any entry with only two disk
-accesses.  DBM files allow a Perl program to keep a persistent
-L</hash> across multiple invocations.  You can L<tie|perlfunc/tie>
-your hash variables to various DBM implementations--see L<AnyDBM_File>
-and L<DB_File>.
+Stands for X<DBM (Database Management) routines>X<Database Management (DBM)
+routines>“Database Management” routines, a set of routines that emulate an
+B<associative array> using disk files. The routines use a dynamic hashing
+scheme to locate any entry with only two disk accesses. DBM files allow a
+Perl program to keep a persistent B<hash> across multiple invocations. You
+can C<tie> your hash variables to various DBM implementations.
 
 =item declaration
 
-An L</assertion> that states something exists and perhaps describes
-what it's like, without giving any commitment as to how or where
-you'll use it.  A declaration is like the part of your recipe that
-says, "two cups flour, one large egg, four or five tadpoles..."  See
-L</statement> for its opposite.  Note that some declarations also
-function as statements.  Subroutine declarations also act as
-definitions if a body is supplied.
+An B<assertion> X<declarations, defined>that states something exists and
+perhaps describes what it’s like, without giving any commitment as to how
+or where you’ll use it. A declaration is like the part of your recipe that
+says, “two cups flour, one large egg, four or five tadpoles…” See
+B<statement> for its opposite. Note that some declarations also function
+as statements. Subroutine declarations also act as definitions if a body
+is supplied.
+
+=item declarator
+
+Something X<declarators>that tells your program what sort of variable
+you’d like. Perl doesn’t require you to declare variables, but you can use
+C<my>, C<our>, or C<state> to denote that you want something other than
+the default.
 
 =item decrement
 
-To subtract a value from a variable, as in "decrement C<$x>" (meaning
-to remove 1 from its value) or "decrement C<$x> by 3".
+To X<decrementing values>X<values, decrementing>subtract a value from a
+variable, as in “decrement C<$x>” (meaning to remove 1 from its value) or
+“decrement C<$x> by 3”.
 
 =item default
 
-A L</value> chosen for you if you don't supply a value of your own.
+A B<value> X<default values>X<values, default>chosen for you if you don’t
+supply a value of your own.
 
 =item defined
 
-Having a meaning.  Perl thinks that some of the things people try to
-do are devoid of meaning, in particular, making use of variables that
-have never been given a L</value> and performing certain operations on
-data that isn't there.  For example, if you try to read data past the
-end of a file, Perl will hand you back an undefined value.  See also
-L</false> and L<perlfunc/defined>.
+Having a X<defined (term)>meaning. Perl thinks that some of the things
+people try to do are devoid of meaning; in particular, making use of
+variables that have never been given a B<value> and performing certain
+operations on data that isn’t there. For example, if you try to read data
+past the end of a file, Perl will hand you back an undefined value. See also
+B<false> and the C<defined> entry in Camel chapter 27, “Functions”.
 
 =item delimiter
 
-A L</character> or L</string> that sets bounds to an arbitrarily-sized
-textual object, not to be confused with a L</separator> or
-L</terminator>.  "To delimit" really just means "to surround" or "to
-enclose" (like these parentheses are doing).
-
-=item deprecated modules and features
-
-Deprecated modules and features are those which were part of a stable
-release, but later found to be subtly flawed, and which should be avoided.
-They are subject to removal and/or bug-incompatible reimplementation in
-the next major release (but they will be preserved through maintenance
-releases).  Deprecation warnings are issued under B<-w> or C<use
-diagnostics>, and notices are found in L<perldelta>s, as well as various
-other PODs. Coding practices that misuse features, such as C<my $foo if
-0>, can also be deprecated.
+A B<character> X<delimiters (term)>or B<string> that sets bounds to an
+arbitrarily sized textual object, not to be confused with a B<separator> or
+B<terminator>. “To delimit” really just means “to surround” or “to enclose”
+(like these parentheses are doing).
 
 =item dereference
 
-A fancy computer science term meaning "to follow a L</reference> to
-what it points to".  The "de" part of it refers to the fact that
-you're taking away one level of L</indirection>.
+A fancy X<dereference (term)>X<references, dereference>computer science term
+meaning “to follow a B<reference> to what it points to”. The “de” part of it
+refers to the fact that you’re taking away one level of B<indirection>.
 
 =item derived class
 
-A L</class> that defines some of its L<methods|/method> in terms of a
-more generic class, called a L</base class>.  Note that classes aren't
-classified exclusively into base classes or derived classes: a class
-can function as both a derived class and a base class simultaneously,
-which is kind of classy.
+A B<class> that X<derived classes>X<classes, derived>X<subclasses>X<classes,
+subclasses>defines some of its B<methods> in terms of a more generic class,
+called a B<base class>. Note that classes aren’t classified exclusively into
+base classes or derived classes: a class can function as both a derived
+class and a base class simultaneously, which is kind of classy.
 
 =item descriptor
 
-See L</file descriptor>.
+See B<file descriptor>.
 
 =item destroy
 
-To deallocate the memory of a L</referent> (first triggering its
-C<DESTROY> method, if it has one).
+To deallocate the X<destroy (term)>memory of a B<referent> (first triggering
+its C<DESTROY> method, if it has one).
 
 =item destructor
 
-A special L</method> that is called when an L</object> is thinking
-about L<destroying|/destroy> itself.  A Perl program's C<DESTROY>
-method doesn't do the actual destruction; Perl just
-L<triggers|/trigger> the method in case the L</class> wants to do any
-associated cleanup.
+A special B<method> X<destructor method>X<methods, destructor>that is called
+when an B<object> is thinking about B<destroying> itself. A Perl program’s
+C<DESTROY> method doesn’t do the actual destruction; Perl just B<triggers>
+the method in case the B<class> wants to do any associated cleanup.
 
 =item device
 
-A whiz-bang hardware gizmo (like a disk or tape drive or a modem or a
-joystick or a mouse) attached to your computer, that the L</operating
-system> tries to make look like a L</file> (or a bunch of files).
+A whiz-bang X<devices (term)>hardware gizmo (like a disk or tape drive or a
+modem or a joystick or a mouse) attached to your computer, which the
+B<operating system> tries to make look like a B<file> (or a bunch of files).
 Under Unix, these fake files tend to live in the I</dev> directory.
 
 =item directive
 
-A L</pod> directive.  See L<perlpod>.
+A B<pod> X<directives, defined>directive. See Camel chapter 23, “Plain Old
+Documentation”.
 
 =item directory
 
-A special file that contains other files.  Some L<operating
-systems|/operating system> call these "folders", "drawers", or
-"catalogs".
+A special X<directories, defined>file that contains other files. Some
+B<operating systems> call these “folders”, “drawers”, “catalogues”, or
+“catalogs”.
 
 =item directory handle
 
-A name that represents a particular instance of opening a directory to
-read it, until you close it.  See the L<opendir|perlfunc/opendir>
-function.
+A name X<directory handle>that represents a particular instance of opening a
+directory to read it, until you close it. See the C<opendir> function.
+
+=item discipline
+
+Some X<discipline (I/O layer)>people need this and some people avoid it.
+For Perl, it’s an old way to say B<I/O layer>.
 
 =item dispatch
 
-To send something to its correct destination.  Often used
+To send X<dispatching>something to its correct destination. Often used
 metaphorically to indicate a transfer of programmatic control to a
-destination selected algorithmically, often by lookup in a table of
-function L<references|/reference> or, in the case of object
-L<methods|/method>, by traversing the inheritance tree looking for the
-most specific definition for the method.
+destination selected algorithmically, often by lookup in a table of function
+B<references> or, in the case of object B<methods>, by traversing the
+inheritance tree looking for the most specific definition for the method.
 
 =item distribution
 
-A standard, bundled release of a system of software.  The default
-usage implies source code is included.  If that is not the case, it
-will be called a "binary-only" distribution.
+A standard, X<distributions, defined>bundled release of a system of
+software. The default usage implies source code is included. If that is not
+the case, it will be called a “binary-only” distribution.
 
-=item (to be) dropped modules
+=item dual-lived
 
-When Perl 5 was first released (see L<perlhist>), several modules were
-included, which have now fallen out of common use.  It has been suggested
-that these modules should be removed, since the distribution became rather
-large, and the common criterion for new module additions is now limited to
-modules that help to build, test, and extend perl itself.  Furthermore,
-the CPAN (which didn't exist at the time of Perl 5.0) can become the new
-home of dropped modules. Dropping modules is currently not an option, but
-further developments may clear the last barriers.
+Some X<dual–lived modules>X<modules, dual–lived>modules live both in the
+B<Standard Library> and on B<CPAN>. These modules might be developed on two
+tracks as people modify either version. The trend currently is to untangle
+these situations.
 
 =item dweomer
 
-An enchantment, illusion, phantasm, or jugglery.  Said when Perl's
-magical L</dwimmer> effects don't do what you expect, but rather seem
-to be the product of arcane dweomercraft, sorcery, or wonder working.
-[From Old English]
+An enchantment, illusion, X<dweomer>phantasm, or jugglery. Said when Perl’s
+magical B<dwimmer> effects don’t do what you expect, but rather seem to be
+the product of arcane I<dweomercraft>, sorcery, or wonder working. [From
+Middle English.]
 
 =item dwimmer
 
-DWIM is an acronym for "Do What I Mean", the principle that something
-should just do what you want it to do without an undue amount of fuss.
-A bit of code that does "dwimming" is a "dwimmer".  Dwimming can
-require a great deal of behind-the-scenes magic, which (if it doesn't
-stay properly behind the scenes) is called a L</dweomer> instead.
+DWIM X<DWIM (Do What I Mean) principle>X<Do What I Mean (DWIM) principle>is
+an acronym for X<dwimming>“Do What I Mean”, the principle that something
+should just do what you want it to do without an undue amount of fuss. A bit
+of code that does “dwimming” is a “dwimmer”. Dwimming can require a great
+deal of behind-the-scenes magic, which (if it doesn’t stay properly behind
+the scenes) is called a B<dweomer> instead.
 
 =item dynamic scoping
 
-Dynamic scoping works over a dynamic scope, making variables visible
-throughout the rest of the L</block> in which they are first used and
-in any L<subroutines|/subroutine> that are called by the rest of the
-block.  Dynamically scoped variables can have their values temporarily
-changed (and implicitly restored later) by a L<local|perlfunc/local>
-operator.  (Compare L</lexical scoping>.)  Used more loosely to mean
-how a subroutine that is in the middle of calling another subroutine
-"contains" that subroutine at L</run time>.
-
-=back
-
-=head2 E
-
-=over 4
+Dynamic X<dynamic scope>X<scopes, dynamic>scoping works over a B<dynamic
+scope>, making variables visible throughout the rest of the B<block> in
+which they are first used and in any B<subroutines> that are called by the
+rest of the block. Dynamically scoped variables can have their values
+temporarily changed (and implicitly restored later) by a C<local> operator.
+(Compare B<lexical scoping>.) Used more loosely to mean how a subroutine
+that is in the middle of calling another subroutine “contains” that
+subroutine at B<runtime>.
 
 =item eclectic
 
-Derived from many sources.  Some would say I<too> many.
+Derived X<eclectic (term)>from many sources. Some would say I<too> many.
 
 =item element
 
-A basic building block.  When you're talking about an L</array>, it's
-one of the items that make up the array.
+A basic X<elements, about>building block. When you’re talking about an
+B<array>, it’s one of the items that make up the array.
 
 =item embedding
 
-When something is contained in something else, particularly when that
-might be considered surprising: "I've embedded a complete Perl
-interpreter in my editor!"
-
-=item empty list
-
-See </null list>.
+When X<embedding (term)>something is contained in something else,
+particularly when that might be considered surprising: “I’ve embedded a
+complete Perl interpreter in my editor!”
 
 =item empty subclass test
 
-The notion that an empty L</derived class> should behave exactly like
-its L</base class>.
-
-=item en passant
-
-When you change a L</value> as it is being copied.  [From French, "in
-passing", as in the exotic pawn-capturing maneuver in chess.]
+The notion X<empty subclass test>that an empty B<derived class> should
+behave exactly like its B<base class>.
 
 =item encapsulation
 
-The veil of abstraction separating the L</interface> from the
-L</implementation> (whether enforced or not), which mandates that all
-access to an L</object>'s state be through L<methods|/method> alone.
+The veil of X<encapsulation (term)>abstraction separating the B<interface>
+from the B<implementation> (whether enforced or not), which mandates that
+all access to an B<object>’s state be through B<methods> alone.
 
 =item endian
 
-See L</little-endian> and L</big-endian>.
+See B<little-endian> and B<big-endian>.
+
+=item en passant
+
+When you X<en passant (term)>change a B<value> as it is being copied. [From
+French “in passing”, as in the exotic pawn-capturing maneuver in chess.]
 
 =item environment
 
-The collective set of L<environment variables|/environment variable>
-your L</process> inherits from its parent.  Accessed via C<%ENV>.
+The collectiveX<environment (term)> set of B<environment variables> your
+B<process> inherits from its parent. Accessed via C<%ENV>.
 
 =item environment variable
 
-A mechanism by which some high-level agent such as a user can pass its
-preferences down to its future offspring (child L<processes|/process>,
-grandchild processes, great-grandchild processes, and so on).  Each
-environment variable is a L</key>/L</value> pair, like one entry in a
-L</hash>.
+A mechanism X<environment variables>X<variables, environment>X<environment
+variables>by which some high-level agent such as a user can pass its
+preferences down to its future offspring (child B<processes>, grandchild
+processes, great-grandchild processes, and so on). Each environment
+variable is a B<key>/B<value> pair, like one entry in a B<hash>.
 
 =item EOF
 
-End of File.  Sometimes used metaphorically as the terminating string
-of a L</here document>.
+End of File. X<End of File (EOF)>X<EOF (End of File)>Sometimes used
+metaphorically as the terminating string of a B<here document>.
 
 =item errno
 
-The error number returned by a L</syscall> when it fails.  Perl refers
-to the error by the name C<$!> (or C<$OS_ERROR> if you use the English
-module).
+The X<errno (error number)>X<error number (errno)>error number returned by a
+B<syscall> when it fails. Perl refers to the error by the name C<$!> (or
+C<$OS_ERROR> if you use the English module).
 
 =item error
 
-See L</exception> or L</fatal error>.
+See B<exception> or B<fatal error>.
 
 =item escape sequence
 
-See L</metasymbol>.
+See B<metasymbol>.
 
 =item exception
 
-A fancy term for an error.  See L</fatal error>.
+A fancy term for an error. See B<fatal error>.
 
 =item exception handling
 
-The way a program responds to an error.  The exception handling
-mechanism in Perl is the L<eval|perlfunc/eval> operator.
+The X<exception handling, defined>way a program responds to an error. The
+exception-handling mechanism in Perl is the C<eval> operator.
 
 =item exec
 
-To throw away the current L</process>'s program and replace it with
-another without exiting the process or relinquishing any resources
+To X<exec function>throw away the current B<process>’s program and replace
+it with another, without exiting the process or relinquishing any resources
 held (apart from the old memory image).
 
 =item executable file
 
-A L</file> that is specially marked to tell the L</operating system>
-that it's okay to run this file as a program.  Usually shortened to
-"executable".
+A B<file> X<executable files>X<files, executable>that is specially marked to
+tell the B<operating system> that it’s okay to run this file as a program.
+Usually shortened to “executable”.
 
 =item execute
 
-To run a L<program|/executable file> or L</subroutine>.  (Has nothing
-to do with the L<kill|perlfunc/kill> built-in, unless you're trying to
-run a L</signal handler>.)
+To run X<execute (term)>a B<program> or B<subroutine>. (Has nothing to do
+with the C<kill> built-in, unless you’re trying to run a B<signal handler>.)
 
 =item execute bit
 
-The special mark that tells the operating system it can run this
-program.  There are actually three execute bits under Unix, and which
-bit gets used depends on whether you own the file singularly,
-collectively, or not at all.
+The X<execute bit>special mark that tells the operating system it can run
+this program. There are actually three execute bits under Unix, and which
+bit gets used depends on whether you own the file singularly, collectively,
+or not at all.
 
 =item exit status
 
-See L</status>.
+See B<status>.
+
+=item exploit
+
+Used X<exploits, security>as a noun in this case, this refers to a known way
+to compromise a program to get it to do something the author didn’t intend.
+Your task is to write unexploitable programs.
 
 =item export
 
-To make symbols from a L</module> available for L</import> by other modules.
+To make X<exporting, defined>symbols from a B<module> available for
+B<import> by other modules.
 
 =item expression
 
-Anything you can legally say in a spot where a L</value> is required.
-Typically composed of L<literals|/literal>, L<variables|/variable>,
-L<operators|/operator>, L<functions|/function>, and L</subroutine>
-calls, not necessarily in that order.
+Anything X<expressions, defined>X<expressions>you can legally say in a spot
+where a B<value> is required. Typically composed of B<literals>,
+B<variables>, B<operators>, B<functions>, and B<subroutine> calls, not
+necessarily in that order.
 
 =item extension
 
-A Perl module that also pulls in compiled C or C++ code.  More
-generally, any experimental option that can be compiled into Perl,
-such as multithreading.
-
-=back
-
-=head2 F
-
-=over 4
+A Perl module X<extensions, defined>that also pulls in B<compiled> C or C++
+code. More generally, any experimental option that can be B<compiled> into
+Perl, such as multithreading.
 
 =item false
 
-In Perl, any value that would look like C<""> or C<"0"> if evaluated
-in a string context.  Since undefined values evaluate to C<"">, all
-undefined values are false (including the L</null list>), but not all
-false values are undefined.
+In Perl, any value X<false values>X<values, false>that would look like C<"">
+or C<"0"> if evaluated in a string context. Since undefined values evaluate
+to C<"">, all undefined values are false, but not all false values are
+undefined.
 
 =item FAQ
 
-Frequently Asked Question (although not necessarily frequently
-answered, especially if the answer appears in the Perl FAQ shipped
-standard with Perl).
+Frequently Asked QuestionX<FAQ (Frequently Asked
+Question)>X<Frequently Asked Question (FAQ)> (although not necessarily
+frequently answered, especially if the answer appears in the Perl FAQ
+shipped standard with Perl).
 
 =item fatal error
 
-An uncaught L</exception>, which causes termination of the L</process>
-after printing a message on your L</standard error> stream.  Errors
-that happen inside an L<eval|perlfunc/eval> are not fatal.  Instead,
-the L<eval|perlfunc/eval> terminates after placing the exception
-message in the C<$@> (C<$EVAL_ERROR>) variable.  You can try to
-provoke a fatal error with the L<die|perlfunc/die> operator (known as
-throwing or raising an exception), but this may be caught by a
-dynamically enclosing L<eval|perlfunc/eval>.  If not caught, the
-L<die|perlfunc/die> becomes a fatal error.
+An uncaught B<exception>, X<fatal errors>which causes termination of the
+B<process> after printing a message on your B<standard error> stream. Errors
+that happen inside an C<eval> are not fatal. Instead, the C<eval> terminates
+after placing the exception message in the C<$@> (C<$EVAL_ERROR>) variable.
+You can try to provoke a fatal error with the C<die> operator (known as
+throwing or raising an exception), but this may be caught by a dynamically
+enclosing C<eval>. If not caught, the C<die> becomes a fatal error.
+
+=item feeping creaturism
+
+A spoonerism X<feeping creaturism>X<creeping featurism>of “creeping
+featurism”, noting the biological urge to add just one more feature to
+a program.
 
 =item field
 
-A single piece of numeric or string data that is part of a longer
-L</string>, L</record>, or L</line>.  Variable-width fields are usually
-split up by L<separators|/separator> (so use L<split|perlfunc/split> to
-extract the fields), while fixed-width fields are usually at fixed
-positions (so use L<unpack|perlfunc/unpack>).  L<Instance
-variables|/instance variable> are also known as fields.
+A single X<fields (term)>piece of numeric or string data that is part of a
+longer B<string>, B<record>, or B<line>. Variable-width fields are usually
+split up by B<separators> (so use C<split> to extract the fields), while
+fixed-width fields are usually at fixed positions (so use C<unpack>).
+B<Instance variables> are also known as “fields”.
 
 =item FIFO
 
-First In, First Out.  See also L</LIFO>.  Also, a nickname for a
-L</named pipe>.
+First In, First Out.X<First In, First Out (FIFO)>X<FIFO (First In, First
+Out)> See also B<LIFO>. Also a nickname for a B<named pipe>.
 
 =item file
 
-A named collection of data, usually stored on disk in a L</directory>
-in a L</filesystem>.  Roughly like a document, if you're into office
-metaphors.  In modern filesystems, you can actually give a file more
-than one name.  Some files have special properties, like directories
-and devices.
+A named X<files, defined>collection of data, usually stored on disk in a
+B<directory> in a B<filesystem>. Roughly like a document, if you’re into
+office metaphors. In modern filesystems, you can actually give a file more
+than one name. Some files have special properties, like directories and
+devices.
 
 =item file descriptor
 
-The little number the L</operating system> uses to keep track of which
-opened L</file> you're talking about.  Perl hides the file descriptor
-inside a L</standard IE<sol>O> stream and then attaches the stream to
-a L</filehandle>.
-
-=item file test operator
-
-A built-in unary operator that you use to determine whether something
-is L</true> about a file, such as C<-o $filename> to test whether
-you're the owner of the file.
+The little X<file descriptors>X<descriptors, file>number the B<operating
+system> uses to keep track of which opened B<file> you’re talking about.
+Perl hides the file descriptor inside a B<standard I/O> stream and then
+attaches the stream to a B<filehandle>.
 
 =item fileglob
 
-A "wildcard" match on L<filenames|/filename>.  See the
-L<glob|perlfunc/glob> function.
+A “wildcard” X<fileglobs>match on B<filenames>. See the C<glob> function.
 
 =item filehandle
 
-An identifier (not necessarily related to the real name of a file)
-that represents a particular instance of opening a file until you
-close it.  If you're going to open and close several different files
-in succession, it's fine to open each of them with the same
-filehandle, so you don't have to write out separate code to process
-each file.
+An identifier X<filehandles, about>(not necessarily related to the real
+name of a file) that represents a particular instance of opening a file,
+until you close it. If you’re going to open and close several different
+files in succession, it’s fine to open each of them with the same
+filehandle, so you don’t have to write out separate code to process each
+file.
 
 =item filename
 
-One name for a file.  This name is listed in a L</directory>, and you
-can use it in an L<open|perlfunc/open> to tell the L</operating
-system> exactly which file you want to open, and associate the file
-with a L</filehandle> which will carry the subsequent identity of that
-file in your program, until you close it.
+One name for a X<filenames, about>file. This name is listed in a
+B<directory>. You can use it in an C<open> to tell the B<operating system>
+exactly which file you want to open, and associate the file with a
+B<filehandle>, which will carry the subsequent identity of that file in
+your program, until you close it.
 
 =item filesystem
 
-A set of L<directories|/directory> and L<files|/file> residing on a
-partition of the disk.  Sometimes known as a "partition".  You can
-change the file's name or even move a file around from directory to
-directory within a filesystem without actually moving the file itself,
-at least under Unix.
+A set X<filesystems, defined>of B<directories> and B<files> residing on a
+partition of the disk. Sometimes known as a “partition”. You can change the
+file’s name or even move a file around from directory to directory within a
+filesystem without actually moving the file itself, at least under Unix.
+
+=item file test operator
+
+A built-in X<file test operators, about>unary operator that you use to
+determine whether something is B<true> about a file, such as C<–o
+$filename> to test whether you’re the owner of the file.
 
 =item filter
 
-A program designed to take a L</stream> of input and transform it into
-a stream of output.
+A X<filters, defined>program designed to take a B<stream> of input and
+transform it into a stream of output.
+
+=item first-come
+
+The X<first–come permissions>X<permissions, first–come>first B<PAUSE>
+author to upload a B<namespace> automatically becomes the B<primary
+maintainer> for that namespace. The “first come” permissions distinguish a
+B<primary maintainer> who was assigned that role from one who received it
+automatically.
 
 =item flag
 
-We tend to avoid this term because it means so many things.  It may
-mean a command-line L</switch> that takes no argument
-itself (such as Perl's B<-n> and B<-p>
-flags) or, less frequently, a single-bit indicator (such as the
-C<O_CREAT> and C<O_EXCL> flags used in
-L<sysopen|perlfunc/sysopen>).
+We X<flags (term)>tend to avoid this term because it means so many things.
+It may mean a command-line B<switch> that takes no argument itself (such as
+Perl’s C<–n> and C<–p> flags) or, less frequently, a single-bit indicator
+(such as the C<O_CREAT> and C<O_EXCL> flags used in C<sysopen>). Sometimes
+informally used to refer to certain regex modifiers.
 
 =item floating point
 
-A method of storing numbers in "scientific notation", such that the
-precision of the number is independent of its magnitude (the decimal
-point "floats").  Perl does its numeric work with floating-point
-numbers (sometimes called "floats"), when it can't get away with
-using L<integers|/integer>.  Floating-point numbers are mere
+A X<floating point methods>X<methods, floating point>method of storing
+numbers in “scientific notation”, such that the precision of the number is
+independent of its magnitude (the decimal point “floats”). Perl does its
+numeric work with floating-point numbers (sometimes called “floats”) when
+it can’t get away with using B<integers>. Floating-point numbers are mere
 approximations of real numbers.
 
 =item flush
 
-The act of emptying a L</buffer>, often before it's full.
+The act of X<flushing buffers>X<buffers, flushing>emptying a B<buffer>,
+often before it’s full.
 
 =item FMTEYEWTK
 
-Far More Than Everything You Ever Wanted To Know.  An exhaustive
-treatise on one narrow topic, something of a super-L</FAQ>.  See Tom
-for far more.
+Far More Than Everything You Ever Wanted To KnowX<FMTEYEWTK acronym>. An
+exhaustive treatise on one narrow topic, something of a super-B<FAQ>. See
+Tom for far more.
+
+=item foldcase
+
+The casemap X<foldcase (term)>used in Unicode when comparing or matching
+without regard to case. Comparing lower-, title-, or uppercase are all
+unreliable due to Unicode’s complex, one-to-many case mappings. Foldcase is
+a B<lowercase> variant (using a partially decomposed B<normalization> form
+for certain codepoints) created specifically to resolve this.
 
 =item fork
 
-To create a child L</process> identical to the parent process at its
-moment of conception, at least until it gets ideas of its own.  A
-thread with protected memory.
+To create a X<forking processes>X<processes, forking>child B<process>
+identical to the parent process at its moment of conception, at least until
+it gets ideas of its own. A thread with protected memory.
 
 =item formal arguments
 
-The generic names by which a L</subroutine> knows its
-L<arguments|/argument>.  In many languages, formal arguments are
-always given individual names, but in Perl, the formal arguments are
-just the elements of an array.  The formal arguments to a Perl program
-are C<$ARGV[0]>, C<$ARGV[1]>, and so on.  Similarly, the formal
-arguments to a Perl subroutine are C<$_[0]>, C<$_[1]>, and so on.  You
-may give the arguments individual names by assigning the values to a
-L<my|perlfunc/my> list.  See also L</actual arguments>.
+The X<formal arguments>X<arguments, formal>generic names by which a
+B<subroutine> knows its B<arguments>. In many languages, formal arguments
+are always given individual names; in Perl, the formal arguments are just
+the elements of an array. The formal arguments to a Perl program are
+C<$ARGV[0]>, C<$ARGV[1]>, and so on. Similarly, the formal arguments to a
+Perl subroutine are C<$_[0]>, C<$_[1]>, and so on. You may give the
+arguments individual names by assigning the values to a C<my> list. See
+also B<actual arguments>.
 
 =item format
 
-A specification of how many spaces and digits and things to put
-somewhere so that whatever you're printing comes out nice and pretty.
+A X<formats, defined>specification of how many spaces and digits and things
+to put somewhere so that whatever you’re printing comes out nice and
+pretty.
 
 =item freely available
 
-Means you don't have to pay money to get it, but the copyright on it
-may still belong to someone else (like Larry).
+Means X<freely available (term)>you don’t have to pay money to get it, but
+the copyright on it may still belong to someone else (like Larry).
 
 =item freely redistributable
 
-Means you're not in legal trouble if you give a bootleg copy of it to
-your friends and we find out about it.  In fact, we'd rather you gave
-a copy to all your friends.
+Means X<freely redistributable (term)>you’re not in legal trouble if you
+give a bootleg copy of it to your friends and we find out about it. In
+fact, we’d rather you gave a copy to all your friends.
 
 =item freeware
 
-Historically, any software that you give away, particularly if you
-make the source code available as well.  Now often called C<open
-source software>.  Recently there has been a trend to use the term in
-contradistinction to L</open source software>, to refer only to free
-software released under the Free Software Foundation's GPL (General
-Public License), but this is difficult to justify etymologically.
+Historically, X<freeware (term)>any software that you give away,
+particularly if you make the source code available as well. Now often
+called B<open source software>. Recently there has been a trend to use the
+term in contradistinction to B<open source software>, to refer only to free
+software released under the X<Free Software Foundation>Free Software
+Foundation’s GPL (General Public License), but this is difficult to justify
+etymologically.
 
 =item function
 
-Mathematically, a mapping of each of a set of input values to a
-particular output value.  In computers, refers to a L</subroutine> or
-L</operator> that returns a L</value>.  It may or may not have input
-values (called L<arguments|/argument>).
+Mathematically, X<functions, about>a mapping of each of a set of input
+values to a particular output value. In computers, refers to a
+B<subroutine> or B<operator> that returns a B<value>. It may or may not
+have input values (called B<arguments>).
 
 =item funny character
 
-Someone like Larry, or one of his peculiar friends.  Also refers to
-the strange prefixes that Perl requires as noun markers on its
-variables.
-
-=back
-
-=head2 G
-
-=over 4
+Someone X<funny characters>X<characters, funny>like Larry, or one of his
+peculiar friends. Also refers to the strange prefixes that Perl requires as
+noun markers on its variables.
 
 =item garbage collection
 
-A misnamed feature--it should be called, "expecting your mother to
-pick up after you".  Strictly speaking, Perl doesn't do this, but it
-relies on a reference-counting mechanism to keep things tidy.
-However, we rarely speak strictly and will often refer to the
-reference-counting scheme as a form of garbage collection.  (If it's
-any comfort, when your interpreter exits, a "real" garbage collector
-runs to make sure everything is cleaned up if you've been messy with
-circular references and such.)
+A misnamed feature—X<garbage collection, defined>it should be called,
+“expecting your mother to pick up after you”. Strictly speaking, Perl
+doesn’t do this, but it relies on a reference-counting mechanism to keep
+things tidy. However, we rarely speak strictly and will often refer to the
+reference-counting scheme as a form of garbage collection. (If it’s any
+comfort, when your interpreter exits, a “real” garbage collector runs to
+make sure everything is cleaned up if you’ve been messy with circular
+references and such.)
 
 =item GID
 
-Group ID--in Unix, the numeric group ID that the L</operating system>
-uses to identify you and members of your L</group>.
+Group ID—in Unix, X<GID (Group ID)>X<Group ID (GID)>the numeric group ID
+that the B<operating system> uses to identify you and members of your
+B<group>.
 
 =item glob
 
-Strictly, the shell's C<*> character, which will match a "glob" of
-characters when you're trying to generate a list of filenames.
-Loosely, the act of using globs and similar symbols to do pattern
-matching.  See also L</fileglob> and L</typeglob>.
+Strictly, the X<glob (* character)>shell’s C<*> character, which will match
+a “glob” of characters when you’re trying to generate a list of filenames.
+Loosely, the act of using globs and similar symbols to do pattern matching.
+See also B<fileglob> and B<typeglob>.
 
 =item global
 
-Something you can see from anywhere, usually used of
-L<variables|/variable> and L<subroutines|/subroutine> that are visible
-everywhere in your program.  In Perl, only certain special variables
-are truly global--most variables (and all subroutines) exist only in
-the current L</package>.  Global variables can be declared with
-L<our|perlfunc/our>.  See L<perlfunc/our>.
+Something X<global (term)>you can see from anywhere, usually used of
+B<variables> and B<subroutines> that are visible everywhere in your
+program.  In Perl, only certain special variables are truly global—most
+variables (and all subroutines) exist only in the current B<package>.
+Global variables can be declared with C<our>. See “Global Declarations” in
+Camel chapter 4, “Statements and Declarations”.
 
 =item global destruction
 
-The L</garbage collection> of globals (and the running of any
-associated object destructors) that takes place when a Perl
-L</interpreter> is being shut down.  Global destruction should not be
+The B<garbage X<global destruction>collection> of globals (and the running
+of any associated object destructors) that takes place when a Perl
+B<interpreter> is being shut down. Global destruction should not be
 confused with the Apocalypse, except perhaps when it should.
 
 =item glue language
 
-A language such as Perl that is good at hooking things together that
-weren't intended to be hooked together.
+A language X<glue language>such as Perl that is good at hooking things
+together that weren’t intended to be hooked together.
 
 =item granularity
 
-The size of the pieces you're dealing with, mentally speaking.
+The size of the X<granularity>pieces you’re dealing with, mentally
+speaking.
+
+=item grapheme
+
+A graphene is X<graphemes, defined>an allotrope of carbon arranged in a
+hexagonal crystal lattice one atom thick. A B<grapheme>, or more fully, a
+I<grapheme cluster string> is a single user-visible B<character>, which may
+in turn be several characters (B<codepoints>) long. For example, a carriage
+return plus a line feed is a single grapheme but two characters, while a
+“ȫ” is a single grapheme but one, two, or even three characters, depending
+on B<normalization>.
 
 =item greedy
 
-A L</subpattern> whose L</quantifier> wants to match as many things as
-possible.
+A B<subpattern> X<greedy subpatterns>X<subpatterns, greedy>whose
+B<quantifier> wants to match as many things as possible.
 
 =item grep
 
-Originally from the old Unix editor command for "Globally search for a
-Regular Expression and Print it", now used in the general sense of any
-kind of search, especially text searches.  Perl has a built-in
-L<grep|perlfunc/grep> function that searches a list for elements
-matching any given criterion, whereas the I<grep>(1) program searches
-for lines matching a L</regular expression> in one or more files.
+Originally X<grep function>from the old Unix editor command for “Globally
+search for a Regular Expression and Print it”, now used in the general
+sense of any kind of search, especially text searches. Perl has a built-in
+C<grep> function that searches a list for elements matching any given
+criterion, whereas the B<grep>(1) program searches for lines matching a
+B<regular expression> in one or more files.
 
 =item group
 
-A set of users of which you are a member.  In some operating systems
-(like Unix), you can give certain file access permissions to other
-members of your group.
+A set of users X<groups, defined>of which you are a member. In some
+operating systems (like Unix), you can give certain file access permissions
+to other members of your group.
 
 =item GV
 
-An internal "glob value" typedef, holding a L</typeglob>.  The L</GV>
-type is a subclass of L</SV>.
-
-=back
-
-=head2 H
-
-=over 4
+An internal “glob value” X<GV (glob value)>X<glob value (GV)>typedef,
+holding a B<typeglob>. The C<GV> type is a subclass of B<SV>.
 
 =item hacker
 
-Someone who is brilliantly persistent in solving technical problems,
-whether these involve golfing, fighting orcs, or programming.  Hacker
-is a neutral term, morally speaking.  Good hackers are not to be
-confused with evil L<crackers|/cracker> or clueless L<script
-kiddies|/script kiddie>.  If you confuse them, we will presume that
-you are either evil or clueless.
+Someone X<hackers>who is brilliantly persistent in solving technical
+problems, whether these involve golfing, fighting orcs, or programming.
+Hacker is a neutral term, morally speaking. Good hackers are not to be
+confused with evil B<crackers> or clueless B<script kiddies>. If you
+confuse them, we will presume that you are either evil or clueless.
 
 =item handler
 
-A L</subroutine> or L</method> that is called by Perl when your
-program needs to respond to some internal event, such as a L</signal>,
-or an encounter with an operator subject to L</operator overloading>.
-See also L</callback>.
+A B<subroutine> X<handlers, defined>or B<method> that Perl calls when your
+program needs to respond to some internal event, such as a B<signal>, or an
+encounter with an operator subject to B<operator overloading>. See also
+B<callback>.
 
 =item hard reference
 
-A L</scalar> L</value> containing the actual address of a
-L</referent>, such that the referent's L</reference> count accounts
-for it.  (Some hard references are held internally, such as the
-implicit reference from one of a L</typeglob>'s variable slots to its
-corresponding referent.)  A hard reference is different from a
-L</symbolic reference>.
+A B<scalar> B<value> X<hard references, about>X<references, hard>containing
+the actual address of a B<referent>, such that the referent’s B<reference>
+count accounts for it. (Some hard references are held internally, such as
+the implicit reference from one of a B<typeglob>’s variable slots to its
+corresponding referent.) A hard reference is different from a B<symbolic
+reference>.
 
 =item hash
 
-An unordered association of L</key>/L</value> pairs, stored such that
-you can easily use a string L</key> to look up its associated data
-L</value>.  This glossary is like a hash, where the word to be defined
-is the key, and the definition is the value.  A hash is also sometimes
-septisyllabically called an "associative array", which is a pretty
-good reason for simply calling it a "hash" instead. A hash can optionally
-be L<restricted|/restricted hash> to a fixed set of keys.
+An unordered X<hashes, about>association of B<key>/B<value> X<key/value
+pairs, about>pairs, stored such that you can easily use a string B<key> to
+look up its associated data B<value>. This glossary is like a hash, where
+the word to be defined is the key and the definition is the value. A hash
+is also sometimes septisyllabically called an “associative array”, which is
+a pretty good reason for simply calling it a “hash” instead.
 
 =item hash table
 
-A data structure used internally by Perl for implementing associative
-arrays (hashes) efficiently.  See also L</bucket>.
+A data X<hash tables>structure used internally by Perl for implementing
+associative arrays (hashes) efficiently. See also B<bucket>.
 
 =item header file
 
-A file containing certain required definitions that you must include
-"ahead" of the rest of your program to do certain obscure operations.
-A C header file has a I<.h> extension.  Perl doesn't really have
-header files, though historically Perl has sometimes used translated
-I<.h> files with a I<.ph> extension.  See L<perlfunc/require>.
-(Header files have been superseded by the L</module> mechanism.)
+A file X<header files>X<files, header>containing certain required
+definitions that you must include “ahead” of the rest of your program to do
+certain obscure operations. A C header file has a I<.h> extension. Perl
+doesn’t really have header files, though historically Perl has sometimes
+used translated I<.h> files with a I<.ph> extension. See C<require> in
+Camel chapter 27, “Functions”. (Header files have been superseded by the
+B<module> mechanism.)
 
 =item here document
 
-So called because of a similar construct in L<shells|/shell> that
-pretends that the L<lines|/line> following the L</command> are a
-separate L</file> to be fed to the command, up to some terminating
-string.  In Perl, however, it's just a fancy form of quoting.
+So X<here documents>called because of a similar construct in B<shells> that
+pretends that the B<lines> following the B<command> are a separate B<file>
+to be fed to the command, up to some terminating string. In Perl, however,
+it’s just a fancy form of quoting.
 
 =item hexadecimal
 
-A number in base 16, "hex" for short.  The digits for 10 through 16
-are customarily represented by the letters C<a> through C<f>.
-Hexadecimal constants in Perl start with C<0x>.  See also
-L<perlfunc/hex>.
+A X<hexadecimals>number in base 16, “hex” for short. The digits for 10
+through 16 are customarily represented by the letters C<a> through C<f>.
+Hexadecimal constants in Perl start with C<0x>. See also the C<hex>
+function in Camel chapter 27, “Functions”.
 
 =item home directory
 
-The directory you are put into when you log in.  On a Unix system, the
-name is often placed into C<$ENV{HOME}> or C<$ENV{LOGDIR}> by
-I<login>, but you can also find it with C<(getpwuid($E<lt>))[7]>.
-(Some platforms do not have a concept of a home directory.)
+The X<home directory>X<directories, home>directory you are put into when
+you log in. On a Unix system, the name is often placed into C<$ENV{HOME}>
+or C<$ENV{LOGDIR}> by I<login>, but you can also find it with
+C<(get>C<pwuid($E<lt>))[7]>. (Some platforms do not have a concept of a
+home directory.)
 
 =item host
 
-The computer on which a program or other data resides.
+The computer X<host computers>on which a program or other data resides.
 
 =item hubris
 
-Excessive pride, the sort of thing Zeus zaps you for.  Also the
-quality that makes you write (and maintain) programs that other people
-won't want to say bad things about.  Hence, the third great virtue of
-a programmer.  See also L</laziness> and L</impatience>.
+Excessive pride, X<hubris quality>the sort of thing for which Zeus zaps
+you.  Also the quality that makes you write (and maintain) programs that
+other people won’t want to say bad things about. Hence, the third great
+virtue of a programmer. See also B<laziness> and B<impatience>.
 
 =item HV
 
-Short for a "hash value" typedef, which holds Perl's internal
-representation of a hash.  The L</HV> type is a subclass of L</SV>.
-
-=back
-
-=head2 I
-
-=over 4
+Short for a “hash value” X<HV (hash value)>X<hash value (HV)>typedef, which
+holds Perl’s internal representation of a hash. The C<HV> type is a
+subclass of B<SV>.
 
 =item identifier
 
-A legally formed name for most anything in which a computer program
-might be interested.  Many languages (including Perl) allow
-identifiers that start with a letter and contain letters and digits.
-Perl also counts the underscore character as a valid letter.  (Perl
-also has more complicated names, such as L</qualified> names.)
+A legally X<identifiers, defined>formed name for most anything in which a
+computer program might be interested. Many languages (including Perl) allow
+identifiers to start with an alphabetic character, and then contain
+alphabetics and digits. Perl also allows connector punctuation like the
+underscore character wherever it allows alphabetics. (Perl also has more
+complicated names, like B<qualified> names.)
 
 =item impatience
 
-The anger you feel when the computer is being lazy.  This makes you
-write programs that don't just react to your needs, but actually
-anticipate them.  Or at least that pretend to.  Hence, the second
-great virtue of a programmer.  See also L</laziness> and L</hubris>.
+The anger X<impatience quality>you feel when the computer is being lazy.
+This makes you write programs that don’t just react to your needs, but
+actually anticipate them. Or at least that pretend to. Hence, the second
+great virtue of a programmer. See also B<laziness> and B<hubris>.
 
 =item implementation
 
-How a piece of code actually goes about doing its job.  Users of the
-code should not count on implementation details staying the same
-unless they are part of the published L</interface>.
+How a X<implementation (term)>piece of code actually goes about doing its
+job. Users of the code should not count on implementation details staying
+the same unless they are part of the published B<interface>.
 
 =item import
 
-To gain access to symbols that are exported from another module.  See
-L<perlfunc/use>.
+To gain X<import (term)>access to symbols that are exported from another
+module. See C<use> in Camel chapter 27, “Functions”.
 
 =item increment
 
-To increase the value of something by 1 (or by some other number, if
-so specified).
+To increase the X<incrementing values>X<values, incrementing>value of
+something by 1 (or by some other number, if so specified).
 
 =item indexing
 
-In olden days, the act of looking up a L</key> in an actual index
-(such as a phone book), but now merely the act of using any kind of
-key or position to find the corresponding L</value>, even if no index
-is involved.  Things have degenerated to the point that Perl's
-L<index|perlfunc/index> function merely locates the position (index)
-of one string in another.
+In olden days, X<indexing (term)>the act of looking up a B<key> in an
+actual index (such as a phone book). But now it's merely the act of using
+any kind of key or position to find the corresponding B<value>, even if no
+index is involved. Things have degenerated to the point that Perl’s
+C<index> function merely locates the position (index) of one string in
+another.
 
 =item indirect filehandle
 
-An L</expression> that evaluates to something that can be used as a
-L</filehandle>: a L</string> (filehandle name), a L</typeglob>, a
-typeglob L</reference>, or a low-level L</IO> object.
-
-=item indirect object
-
-In English grammar, a short noun phrase between a verb and its direct
-object indicating the beneficiary or recipient of the action.  In
-Perl, C<print STDOUT "$foo\n";> can be understood as "verb
-indirect-object object" where L</STDOUT> is the recipient of the
-L<print|perlfunc/print> action, and C<"$foo"> is the object being
-printed.  Similarly, when invoking a L</method>, you might place the
-invocant between the method and its arguments:
-
-  $gollum = new Pathetic::Creature "Smeagol";
-  give $gollum "Fisssssh!";
-  give $gollum "Precious!";
-
-In modern Perl, calling methods this way is often considered bad practice and
-to be avoided.
-
-=item indirect object slot
-
-The syntactic position falling between a method call and its arguments
-when using the indirect object invocation syntax.  (The slot is
-distinguished by the absence of a comma between it and the next
-argument.) L</STDERR> is in the indirect object slot here:
-
-  print STDERR "Awake!  Awake!  Fear, Fire,
-      Foes!  Awake!\n";
+An B<expression> X<indirect filehandles>X<filehandles, indirect>that
+evaluates to something that can be used as a B<filehandle>: a B<string>
+(filehandle name), a B<typeglob>, a typeglob B<reference>, or a low-level
+B<IO> object.
 
 =item indirection
 
-If something in a program isn't the value you're looking for but
-indicates where the value is, that's indirection.  This can be done
-with either L<symbolic references|/symbolic reference> or L<hard
-references|/hard reference>.
+If something in a X<indirection (term)>program isn’t the value you’re
+looking for but indicates where the value is, that’s indirection. This can
+be done with either B<symbolic references> or B<hard>.
+
+=item indirect object
+
+In English grammar, X<indirect objects, defined>X<objects, indirect>a short
+noun phrase between a verb and its direct object indicating the beneficiary
+or recipient of the action. In Perl, C<print STDOUT "$foo\n";> can be
+understood as “verb indirect-object object”, where C<STDOUT> is the
+recipient of the C<print> action, and C<"$foo"> is the object being
+printed.  Similarly, when invoking a B<method>, you might place the
+invocant in the dative slot between the method and its arguments:
+
+    $gollum = new Pathetic::Creature "Sméagol";
+    give $gollum "Fisssssh!";
+    give $gollum "Precious!";
+
+=item indirect object slot
+
+The syntactic X<indirect object slot>position falling between a method call
+and its arguments when using the indirect object invocation syntax. (The
+slot is distinguished by the absence of a comma between it and the next
+argument.) C<STDERR> is in the indirect object slot here:
+
+    print STDERR "Awake! Awake! Fear, Fire, Foes! Awake!\n";
 
 =item infix
 
-An L</operator> that comes in between its L<operands|/operand>, such
-as multiplication in C<24 * 7>.
+An B<operator> that X<infix operators>comes in between its B<operands>,
+such as multiplication in C<24 * 7>.
 
 =item inheritance
 
-What you get from your ancestors, genetically or otherwise.  If you
-happen to be a L</class>, your ancestors are called L<base
-classes|/base class> and your descendants are called L<derived
-classes|/derived class>.  See L</single inheritance> and L</multiple
-inheritance>.
+What you get from your X<inheritance, defined>ancestors, genetically or
+otherwise. If you happen to be a B<class>, your ancestors are called B<base
+classes> and your descendants are called B<derived classes>. See B<single
+inheritance> and B<multiple inheritance>.
 
 =item instance
 
-Short for "an instance of a class", meaning an L</object> of that L</class>.
+Short for “an instance of a class”, X<instances (term)>meaning an B<object>
+of that B<class>.
+
+=item instance data
+
+SeeX<instance data> B<instance variable>.
+
+=item instance method
+
+A B<method> of X<instance methods>X<methods, instance>an B<object>, as
+opposed to a B<class method>.
+
+A B<method> whose B<invocant> is an B<object>, not a B<package> name. Every
+object of a class shares all the methods of that class, so an instance
+method applies to all instances of the class, rather than applying to a
+particular instance. Also see B<class method>.
 
 =item instance variable
 
-An L</attribute> of an L</object>; data stored with the particular
-object rather than with the class as a whole.
+An B<attribute> of an B<object>; X<instance variables, defined>X<variables,
+instance>data stored with the particular object rather than with the class
+as a whole.
 
 =item integer
 
-A number with no fractional (decimal) part.  A counting number, like
-1, 2, 3, and so on, but including 0 and the negatives.
+A number X<integers (term)>with no fractional (decimal) part. A counting
+number, like 1, 2, 3, and so on, but including 0 and the negatives.
 
 =item interface
 
-The services a piece of code promises to provide forever, in contrast to
-its L</implementation>, which it should feel free to change whenever it
-likes.
+The services X<interfaces (term)>a piece of code promises to provide
+forever, in contrast to its B<implementation>, which it should feel free to
+change whenever it likes.
 
 =item interpolation
 
-The insertion of a scalar or list value somewhere in the middle of
-another value, such that it appears to have been there all along.  In
-Perl, variable interpolation happens in double-quoted strings and
+The insertion of X<interpolation, defined>a scalar or list value somewhere
+in the middle of another value, such that it appears to have been there all
+along. In Perl, variable interpolation happens in double-quoted strings and
 patterns, and list interpolation occurs when constructing the list of
 values to pass to a list operator or other such construct that takes a
-L</LIST>.
+I<C<LIST>>.
 
 =item interpreter
 
-Strictly speaking, a program that reads a second program and does what
-the second program says directly without turning the program into a
-different form first, which is what L<compilers|/compiler> do.  Perl
-is not an interpreter by this definition, because it contains a kind
-of compiler that takes a program and turns it into a more executable
-form (L<syntax trees|/syntax tree>) within the I<perl> process itself,
-which the Perl L</run time> system then interprets.
+Strictly speaking, X<interpreters, defined>a program that reads a second
+program and does what the second program says directly without turning the
+program into a different form first, which is what B<compilers> do. Perl is
+not an interpreter by this definition, because it contains a kind of
+compiler that takes a program and turns it into a more executable form
+(B<syntax trees>) within the I<perl> process itself, which the Perl
+B<runtime> system then interprets.
 
 =item invocant
 
-The agent on whose behalf a L</method> is invoked.  In a L</class>
-method, the invocant is a package name.  In an L</instance> method,
+The agent on X<invocants, defined>whose behalf a B<method> is invoked. In a
+B<class> method, the invocant is a package name. In an B<instance> method,
 the invocant is an object reference.
 
 =item invocation
 
-The act of calling up a deity, daemon, program, method, subroutine, or
-function to get it do what you think it's supposed to do.  We usually
-"call" subroutines but "invoke" methods, since it sounds cooler.
+The act of X<invocation, method>calling up a deity, daemon, program,
+method, subroutine, or function to get it to do what you think it’s
+supposed to do.  We usually “call” subroutines but “invoke” methods, since
+it sounds cooler.
 
 =item I/O
 
-Input from, or output to, a L</file> or L</device>.
+Input from, or X<I/O (Input/Output), defined>X<Input/Output (I/O),
+defined>output to, a B<file> or B<device>.
 
 =item IO
 
-An internal I/O object.  Can also mean L</indirect object>.
+An internal I/O object. Can also mean B<indirect object>.
+
+=item I/O layer
+
+One of the X<I/O layer>filters between the data and what you get as input
+or what you end up with as output.
+
+=item IPA
+
+India Pale Ale. Also the X<International Phonetic Alphabet (IPA)>X<IPA
+(International Phonetic Alphabet)>International Phonetic Alphabet, the
+standard alphabet used for phonetic notation worldwide. Draws heavily on
+Unicode, including many combining characters.
 
 =item IP
 
-Internet Protocol, or Intellectual Property.
+Internet ProtocolX<Internet Protocol (IP)>X<IP (Internet Protocol)>, or
+X<IP (Intellectual Property)>X<Intellectual Property (IP)>Intellectual
+Property.
 
 =item IPC
 
-Interprocess Communication.
+Interprocess X<Interprocess Communication>X<IPC (Interprocess
+Communication), about>X<communication>Communication.
 
 =item is-a
 
-A relationship between two L<objects|/object> in which one object is
-considered to be a more specific version of the other, generic object:
-"A camel is a mammal."  Since the generic object really only exists in
-a Platonic sense, we usually add a little abstraction to the notion of
-objects and think of the relationship as being between a generic
-L</base class> and a specific L</derived class>.  Oddly enough,
-Platonic classes don't always have Platonic relationships--see
-L</inheritance>.
+A rX<is–a relationship>elationship between two B<objects> in which one
+object is considered to be a more specific version of the other, generic
+object: “A camel is a mammal.” Since the generic object really only exists
+in a Platonic sense, we usually add a little abstraction to the notion of
+objects and think of the relationship as being between a generic B<base
+class> and a specific B<derived class>. Oddly enough, Platonic classes
+don’t always have Platonic relationships—see B<inheritance>.
 
 =item iteration
 
-Doing something repeatedly.
+Doing X<iteration>something repeatedly.
 
 =item iterator
 
-A special programming gizmo that keeps track of where you are in
-something that you're trying to iterate over.  The C<foreach> loop in
-Perl contains an iterator; so does a hash, allowing you to
-L<each|perlfunc/each> through it.
+A special X<iterators>programming gizmo that keeps track of where you are
+in something that you’re trying to iterate over. The C<foreach> loop in
+Perl contains an iterator; so does a hash, allowing you to C<each> through
+it.
 
 =item IV
 
-The integer four, not to be confused with six, Tom's favorite editor.
-IV also means an internal Integer Value of the type a L</scalar> can
-hold, not to be confused with an L</NV>.
-
-=back
-
-=head2 J
-
-=over 4
+The integer X<IV (Integer Value)>X<Integer Value (IV)>four, not to be
+confused with six, Tom’s favorite editor. IV also means an internal Integer
+Value of the type a B<scalar> can hold, not to be confused with an B<NV>.
 
 =item JAPH
 
-"Just Another Perl Hacker," a clever but cryptic bit of Perl code that
-when executed, evaluates to that string.  Often used to illustrate a
-particular Perl feature, and something of an ongoing Obfuscated Perl
-Contest seen in Usenix signatures.
-
-=back
-
-=head2 K
-
-=over 4
+“Just Another Perl Hacker”, a X<JAPH acronym>clever but cryptic bit of Perl
+code that, when executed, evaluates to that string. Often used to
+illustrate a particular Perl feature, and something of an ongoing
+Obfuscated Perl Contest seen in USENET signatures.
 
 =item key
 
-The string index to a L</hash>, used to look up the L</value>
+The X<keys, defined>string index to a B<hash>, used to look up the B<value>
 associated with that key.
 
 =item keyword
 
-See L</reserved words>.
-
-=back
-
-=head2 L
-
-=over 4
+See B<reserved words>.
 
 =item label
 
-A name you give to a L</statement> so that you can talk about that
-statement elsewhere in the program.
+A X<labels, defined>name you give to a B<statement> so that you can talk
+about that statement elsewhere in the program.
 
 =item laziness
 
-The quality that makes you go to great effort to reduce overall energy
-expenditure.  It makes you write labor-saving programs that other
-people will find useful, and document what you wrote so you don't have
-to answer so many questions about it.  Hence, the first great virtue
-of a programmer.  Also hence, this book.  See also L</impatience> and
-L</hubris>.
-
-=item left shift
-
-A L</bit shift> that multiplies the number by some power of 2.
+The X<laziness quality>quality that makes you go to great effort to reduce
+overall energy expenditure. It makes you write labor-saving programs that
+other people will find useful, and then document what you wrote so you
+don’t have to answer so many questions about it. Hence, the first great
+virtue of a programmer. Also hence, this book. See also B<impatience> and
+B<hubris>.
 
 =item leftmost longest
 
-The preference of the L</regular expression> engine to match the
-leftmost occurrence of a L</pattern>, then given a position at which a
-match will occur, the preference for the longest match (presuming the
-use of a L</greedy> quantifier).  See L<perlre> for I<much> more on
-this subject.
+The X<leftmost longest preference>X<regular expressions, leftmost longest
+preference>preference of the B<regular expression> engine to match the
+leftmost occurrence of a B<pattern>, then given a position at which a match
+will occur, the preference for the longest match (presuming the use of a
+B<greedy> quantifier). See Camel chapter 5, “Pattern Matching” for I<much>
+more on this subject.
+
+=item left shift
+
+A B<bit shift> that X<left shift (E<lt>E<lt>) bit operator>X<bit–shift
+operators, left shift>X<E<lt>E<lt> (left shift) bit operator>multiplies the
+number by some power of 2.
 
 =item lexeme
 
-Fancy term for a L</token>.
+Fancy X<lexeme (token)>term for a B<token>.
 
 =item lexer
 
-Fancy term for a L</tokener>.
+Fancy X<lexer (tokener)>term for a B<tokener>.
 
 =item lexical analysis
 
-Fancy term for L</tokenizing>.
+Fancy X<lexical analysis>term for B<tokenizing>.
 
 =item lexical scoping
 
-Looking at your I<Oxford English Dictionary> through a microscope.
-(Also known as L</static scoping>, because dictionaries don't change
-very fast.)  Similarly, looking at variables stored in a private
-dictionary (namespace) for each scope, which are visible only from
-their point of declaration down to the end of the lexical scope in
-which they are declared.  --Syn. L</static scoping>.
---Ant. L</dynamic scoping>.
+Looking X<lexical scopes, defined>X<scopes>at your I<Oxford English
+Dictionary> through a microscope. (Also known as B<static scoping>, because
+dictionaries don’t change very fast.) Similarly, looking at variables
+stored in a private dictionary (namespace) for each scope, which are
+visible only from their point of declaration down to the end of theX<static
+scopes>X<scopes, static> lexical scope in which they are declared. —Syn.
+B<static scoping>. —Ant. B<dynamic scoping>.
 
 =item lexical variable
 
-A L</variable> subject to L</lexical scoping>, declared by
-L<my|perlfunc/my>.  Often just called a "lexical".  (The
-L<our|perlfunc/our> declaration declares a lexically scoped name for a
-global variable, which is not itself a lexical variable.)
+A B<variable> X<lexical variables, about>X<variables, lexical>subject to
+B<lexical scoping>, declared by C<my>. Often just called a “lexical”. (The
+C<our> declaration declares a lexically scoped name for a global variable,
+which is not itself a lexical variable.)
 
 =item library
 
-Generally, a collection of procedures.  In ancient days, referred to a
-collection of subroutines in a I<.pl> file.  In modern times, refers
-more often to the entire collection of Perl L<modules|/module> on your
-system.
+Generally, a X<libraries, defined>collection of procedures. In ancient
+days, referred to a collection of subroutines in a I<.pl> file. In modern
+times, refers more often to the entire collection of Perl B<modules> on
+your system.
 
 =item LIFO
 
-Last In, First Out.  See also L</FIFO>.  A LIFO is usually called a
-L</stack>.
+Last In, First OutX<Last In, First Out (LIFO)>X<LIFO (Last In, First
+Out)>X<stacks, defined>. See also B<FIFO>. A LIFO is usually called a
+B<stack>.
 
 =item line
 
-In Unix, a sequence of zero or more non-newline characters terminated
-with a L</newline> character.  On non-Unix machines, this is emulated
-by the C library even if the underlying L</operating system> has
+In Unix, a X<line (term)>sequence of zero or more nonnewline characters
+terminated with a B<newline> character. On non-Unix machines, this is
+emulated by the C library even if the underlying B<operating system> has
 different ideas.
+
+=item linebreak
+
+A B<grapheme> X<linebreaks>consisting of either a carriage return followed
+by a line feed or any character with the Unicode Vertical Space B<character
+property>.
 
 =item line buffering
 
-Used by a L</standard IE<sol>O> output stream that flushes its
-L</buffer> after every L</newline>.  Many standard I/O libraries
-automatically set up line buffering on output that is going to the
-terminal.
+Used by X<line buffering>X<buffering, line>a B<standard I/O> output stream that
+flushes its B<buffer> after every B<newline>. Many standard I/O libraries
+automatically set up line buffering on output that is going to the terminal.
 
 =item line number
 
-The number of lines read previous to this one, plus 1.  Perl keeps a
-separate line number for each source or input file it opens.  The
-current source file's line number is represented by C<__LINE__>.  The
-current input line number (for the file that was most recently read
-via C<< E<lt>FHE<gt> >>) is represented by the C<$.>
-(C<$INPUT_LINE_NUMBER>) variable.  Many error messages report both
-values, if available.
+The number X<line number>of lines read previous to this one, plus 1. Perl
+keeps a separate line number for each source or input file it opens. The
+current source file’s line number is represented by C<__LINE__>. The
+current input line number (for the file that was most recently read via
+C<E<lt>FHE<gt>>) is represented by the C<$.> (C<$INPUT_LINE_NUMBER>)
+variable. Many error messages report both values, if available.
 
 =item link
 
-Used as a noun, a name in a L</directory>, representing a L</file>.  A
-given file can have multiple links to it.  It's like having the same
-phone number listed in the phone directory under different names.  As
-a verb, to resolve a partially compiled file's unresolved symbols into
-a (nearly) executable image.  Linking can generally be static or
-dynamic, which has nothing to do with static or dynamic scoping.
+Used as a X<links, defined>noun, a name in a B<directory> that represents a
+B<file>. A given file can have multiple links to it. It’s like having the
+same phone number listed in the phone directory under different names. As a
+verb, to resolve a partially B<compiled> file’s unresolved symbols into a
+(nearly) executable image. Linking can generally be static or dynamic,
+which has nothing to do with static or dynamic scoping.
 
 =item LIST
 
-A syntactic construct representing a comma-separated list of
-expressions, evaluated to produce a L</list value>.  Each
-L</expression> in a L</LIST> is evaluated in L</list context> and
+A syntactic X<LIST construct>X<constructs, LIST>construct representing a
+comma- separated list of expressions, evaluated to produce a B<list value>.
+Each B<expression> in a I<C<LIST>> is evaluated in B<list context> and
 interpolated into the list value.
 
 =item list
 
-An ordered set of scalar values.
+An ordered X<lists, defined>set of scalar values.
 
 =item list context
 
-The situation in which an L</expression> is expected by its
-surroundings (the code calling it) to return a list of values rather
-than a single value.  Functions that want a L</LIST> of arguments tell
-those arguments that they should produce a list value.  See also
-L</context>.
+The situation X<list context>X<context, list>in which an B<expression> is
+expected by its surroundings (the code calling it) to return a list of
+values rather than a single value. Functions that want a I<C<LIST>> of
+arguments tell those arguments that they should produce a list value. See
+also B<context>.
 
 =item list operator
 
-An L</operator> that does something with a list of values, such as
-L<join|perlfunc/join> or L<grep|perlfunc/grep>.  Usually used for
-named built-in operators (such as L<print|perlfunc/print>,
-L<unlink|perlfunc/unlink>, and L<system|perlfunc/system>) that do not
-require parentheses around their L</argument> list.
+An B<operator> that X<list operators, about>does something with a list of
+values, such as C<join> or C<grep>. Usually used for named built-in
+operators (such as C<print>, C<unlink>, and C<system>) that do not require
+parentheses around their B<argument> list.
 
 =item list value
 
-An unnamed list of temporary scalar values that may be passed around
-within a program from any list-generating function to any function or
-construct that provides a L</list context>.
+An unnamed X<list values, about>X<values, list>list of temporary scalar
+values that may be passed around within a program from any list-generating
+function to any function or construct that provides a B<list context>.
 
 =item literal
 
-A token in a programming language such as a number or L</string> that
-gives you an actual L</value> instead of merely representing possible
-values as a L</variable> does.
+A token X<literals, defined>in a programming language, such as a number or
+B<string>, that gives you an actual B<value> instead of merely representing
+possible values as a B<variable> does.
 
 =item little-endian
 
-From Swift: someone who eats eggs little end first.  Also used of
-computers that store the least significant L</byte> of a word at a
-lower byte address than the most significant byte.  Often considered
-superior to big-endian machines.  See also L</big-endian>.
+From Swift: X<little–endian, defined>X<endianness, little–endian>someone
+who eats eggs little end first. Also used of computers that store the least
+significant B<byte> of a word at a lower byte address than the most
+significant byte. Often considered superior to big-endian machines. See
+also B<big-endian>.
 
 =item local
 
-Not meaning the same thing everywhere.  A global variable in Perl can
-be localized inside a L<dynamic scope|/dynamic scoping> via the
-L<local|perlfunc/local> operator.
+Not meaning X<local operator, about>the same thing everywhere. A global
+variable in Perl can be localized inside a B<dynamic scope> via the
+C<local> operator.
 
 =item logical operator
 
-Symbols representing the concepts "and", "or", "xor", and "not".
+Symbols X<logical operators, about>representing the concepts “and”, “or”,
+“xor”, and “not”.
 
 =item lookahead
 
-An L</assertion> that peeks at the string to the right of the current
-match location.
+An B<assertion> that X<lookahead assertions>X<assertions (in regexes),
+lookahead>peeks at the string to the right of the current match location.
 
 =item lookbehind
 
-An L</assertion> that peeks at the string to the left of the current
-match location.
+An B<assertion> X<lookbehind assertions>X<assertions (in regexes),
+lookbehind>that peeks at the string to the left of the current match
+location.
 
 =item loop
 
-A construct that performs something repeatedly, like a roller coaster.
+A construct X<loop constructs and statements, about>X<constructs, loop>that
+performs something repeatedly, like a roller coaster.
 
 =item loop control statement
 
-Any statement within the body of a loop that can make a loop
-prematurely stop looping or skip an L</iteration>.  Generally you
-shouldn't try this on roller coasters.
+Any statement X<statements, loop control>within the body of a loop that can
+make a loop prematurely stop looping or skip an B<iteration>. Generally,
+you shouldn’t try this on roller coasters.
 
 =item loop label
 
-A kind of key or name attached to a loop (or roller coaster) so that
-loop control statements can talk about which loop they want to
-control.
+A kind X<loop labels>X<labels, loop>of key or name attached to a loop (or
+roller coaster) so that loop control statements can talk about which loop
+they want to control.
+
+=item lowercase
+
+In Unicode, X<lowercase characters>X<characters, lowercase>not just
+characters with the General Category of Lowercase Letter, but any character
+with the Lowercase property, including Modifier Letters, Letter Numbers,
+some Other Symbols, and one Combining Mark.
 
 =item lvaluable
 
-Able to serve as an L</lvalue>.
+Able to X<lvaluable function>X<functions, lvaluable>serve as an B<lvalue>.
 
 =item lvalue
 
-Term used by language lawyers for a storage location you can assign a
-new L</value> to, such as a L</variable> or an element of an
-L</array>.  The "l" is short for "left", as in the left side of an
-assignment, a typical place for lvalues.  An L</lvaluable> function or
-expression is one to which a value may be assigned, as in C<pos($x) =
-10>.
+Term used by X<lvalue (term)>X<values, lvalue>language lawyers for a
+storage location you can assign a new B<value> to, such as a B<variable> or
+an element of an B<array>. The “l” is short for “left”, as in the left side
+of an assignment, a typical place for lvalues. An B<lvaluable> function or
+expression is one to which a value may be assigned, as in C<pos($x) = 10>.
 
 =item lvalue modifier
 
-An adjectival pseudofunction that warps the meaning of an L</lvalue>
-in some declarative fashion.  Currently there are three lvalue
-modifiers: L<my|perlfunc/my>, L<our|perlfunc/our>, and
-L<local|perlfunc/local>.
-
-=back
-
-=head2 M
-
-=over 4
+An X<lvalue modifier>X<modifiers, lvalue>adjectival pseudofunction that
+warps the meaning of an B<lvalue> in some declarative fashion. Currently
+there are three lvalue modifiers: C<my>, C<our>, and C<local>.
 
 =item magic
 
-Technically speaking, any extra semantics attached to a variable such
-as C<$!>, C<$0>, C<%ENV>, or C<%SIG>, or to any tied variable.
-Magical things happen when you diddle those variables.
+Technically X<magic (term)>speaking, any extra semantics attached to a
+variable such as C<$!>, C<$0>, C<%ENV>, or C<%SIG>, or to any tied
+variable.  Magical things happen when you diddle those variables.
 
 =item magical increment
 
-An L</increment> operator that knows how to bump up alphabetics as
-well as numbers.
+An B<increment> X<magical increment operator>operator that knows how to
+bump up ASCII alphabetics as well as numbers.
 
 =item magical variables
 
-Special variables that have side effects when you access them or
-assign to them.  For example, in Perl, changing elements of the
-C<%ENV> array also changes the corresponding environment variables
-that subprocesses will use.  Reading the C<$!> variable gives you the
-current system error number or message.
+Special variables X<magical variables>X<variables, magical>that have side
+effects when you access them or assign to them. For example, in Perl,
+changing elements of the C<%ENV> array also changes the corresponding
+environment variables that subprocesses will use. Reading the C<$!>
+variable gives you the current system error number or message.
 
 =item Makefile
 
-A file that controls the compilation of a program.  Perl programs
-don't usually need a L</Makefile> because the Perl compiler has plenty
-of self-control.
+A file that X<Makefile>controls the compilation of a program. Perl programs
+don’t usually need a B<Makefile> because the Perl compiler has plenty of
+self-control.
 
 =item man
 
-The Unix program that displays online documentation (manual pages) for
-you.
+The Unix X<man program (Unix)>program that displays online documentation
+(manual pages) for you.
 
 =item manpage
 
-A "page" from the manuals, typically accessed via the I<man>(1)
-command.  A manpage contains a SYNOPSIS, a DESCRIPTION, a list of
-BUGS, and so on, and is typically longer than a page.  There are
-manpages documenting L<commands|/command>, L<syscalls|/syscall>,
-L</library> L<functions|/function>, L<devices|/device>,
-L<protocols|/protocol>, L<files|/file>, and such.  In this book, we
-call any piece of standard Perl documentation (like I<perlop> or
-I<perldelta>) a manpage, no matter what format it's installed in on
-your system.
+A “page” from the X<manpages, defined>manuals, typically accessed via the
+I<man>(1) command. A manpage contains a SYNOPSIS, a DESCRIPTION, a list of
+BUGS, and so on, and is typically longer than a page. There are manpages
+documenting B<commands>, B<syscalls>, B<library> B<functions>, B<devices>,
+B<protocols>, B<files>, and such. In this book, we call any piece of
+standard Perl documentation (like L<perlop> or L<perldelta>) a manpage, no
+matter what format it’s installed in on your system.
 
 =item matching
 
-See L</pattern matching>.
+SeeX<matching> B<pattern matching>.
 
 =item member data
 
-See L</instance variable>.
+SeeX<member data> B<instance variable>.
 
 =item memory
 
-This always means your main memory, not your disk.  Clouding the issue
-is the fact that your machine may implement L</virtual> memory; that
-is, it will pretend that it has more memory than it really does, and
-it'll use disk space to hold inactive bits.  This can make it seem
-like you have a little more memory than you really do, but it's not a
-substitute for real memory.  The best thing that can be said about
-virtual memory is that it lets your performance degrade gradually
-rather than suddenly when you run out of real memory.  But your
-program can die when you run out of virtual memory too, if you haven't
-thrashed your disk to death first.
+This X<memory, defined>always means your main memory, not your disk.
+Clouding the issue is the fact that your machine may implement
+B<virtual> memory; that is, it will pretend that it has more memory than
+it really does, and it’ll use disk space to hold inactive bits. This can
+make it seem like you have a little more memory than you really do, but
+it’s not a substitute for real memory. The best thing that can be said
+about virtual memory is that it lets your performance degrade gradually
+rather than suddenly when you run out of real memory. But your program
+can die when you run out of virtual memory, too—if you haven’t thrashed
+your disk to death first.
 
 =item metacharacter
 
-A L</character> that is I<not> supposed to be treated normally.  Which
-characters are to be treated specially as metacharacters varies
-greatly from context to context.  Your L</shell> will have certain
-metacharacters, double-quoted Perl L<strings|/string> have other
-metacharacters, and L</regular expression> patterns have all the
-double-quote metacharacters plus some extra ones of their own.
+A B<character> that X<metacharacters, about>X<characters, regex
+metacharacters>is I<not> supposed to be treated normally. Which characters
+are to be treated specially as metacharacters varies greatly from context to
+context. Your B<shell> will have certain metacharacters, double-quoted Perl
+B<strings> have other metacharacters,X<regular expressions, metacharacters and>
+and B<regular expression> patterns have all the double-quote metacharacters plus
+some extra ones of their own.
 
 =item metasymbol
 
-Something we'd call a L</metacharacter> except that it's a sequence of
-more than one character.  Generally, the first character in the
-sequence must be a true metacharacter to get the other characters in
-the metasymbol to misbehave along with it.
+Something we’d call X<metasymbols, about>X<escape sequences>a
+B<metacharacter> except that it’s a sequence of more than one character.
+Generally, the first character in the sequence must be a true metacharacter
+to get the other characters in the metasymbol to misbehave along with it.
 
 =item method
 
-A kind of action that an L</object> can take if you tell it to.  See
-L<perlobj>.
+A kind of X<methods, defined>action that an B<object> can take if you tell
+it to. See Camel chapter 12, “Objects”.
+
+=item method resolution order
+
+The path X<method resolution order (mro)>X<mro (method resolution
+order)>Perl takes through C<@INC>. By default, this is a double depth first
+search, once looking for defined methods and once for C<AUTOLOAD>. However,
+Perl lets you configure this with C<mro>.
+
+=item minicpan
+
+A CPAN X<minicpan, defined>X<CPAN (Comprehensive Perl Archive Network),
+minicpan and>mirror that includes just the latest versions for each
+distribution, probably created with C<CPAN::Mini>X<CPAN::Mini module>. See
+Camel chapter 19, “CPAN”.
 
 =item minimalism
 
-The belief that "small is beautiful."  Paradoxically, if you say
-something in a small language, it turns out big, and if you say it in
-a big language, it turns out small.  Go figure.
+The belief X<minimalism>that “small is beautiful”. Paradoxically, if you
+say something in a small language, it turns out big, and if you say it in a
+big language, it turns out small. Go figure.
 
 =item mode
 
-In the context of the L<stat(2)> syscall, refers to the field holding
-the L</permission bits> and the type of the L</file>.
+In the X<mode>context of the I<stat>(2) syscall, refers to the field
+holding the B<permission bits> and the type of the B<file>.
 
 =item modifier
 
-See L</statement modifier>, L</regular expression modifier>, and
-L</lvalue modifier>, not necessarily in that order.
+SeeX<modifiers, defined> B<statement modifier>, B<regular expression>, and
+B<lvalue>, not necessarily in that order.
 
 =item module
 
-A L</file> that defines a L</package> of (almost) the same name, which
-can either L</export> symbols or function as an L</object> class.  (A
-module's main I<.pm> file may also load in other files in support of
-the module.)  See the L<use|perlfunc/use> built-in.
+A B<file> that X<modules, defined>defines a B<package> of (almost) the same
+name, which can either B<export> symbols or function as an B<object> class.
+(A module’s main I<.pm> file may also load in other files in support of the
+module.) See the C<use> built-in.
 
 =item modulus
 
-An integer divisor when you're interested in the remainder instead of
-the quotient.
+An integer X<modulus (%) operator>X<% (modulus) operator>divisor when
+you’re interested in the remainder instead of the quotient.
+
+=item mojibake
+
+When you X<mojibake>speak one language and the computer thinks you’re
+speaking another. You’ll see odd translations when you send UTF‑8, for
+instance, but the computer thinks you sent Latin-1, showing all sorts of
+weird characters instead. The term is written 「文字化け」in Japanese and
+means “character rot”, an apt description. Pronounced [C<modʑibake>] in
+standard B<IPA> phonetics, or approximately “moh-jee-bah-keh”.
 
 =item monger
 
-Short for Perl Monger, a purveyor of Perl.
+Short for X<mongers, Perl>X<Perl mongers>one member of B<Perl mongers>, a
+purveyor of Perl.
 
 =item mortal
 
-A temporary value scheduled to die when the current statement
-finishes.
+A temporary X<mortal value>X<values, mortal>value scheduled to die when the
+current statement finishes.
+
+=item mro
+
+See B<method resolution order>.
 
 =item multidimensional array
 
-An array with multiple subscripts for finding a single element.  Perl
-implements these using L<references|/reference>--see L<perllol> and
-L<perldsc>.
+An array X<multidimensional arrays>X<arrays, multidimensional>with multiple
+subscripts for finding a single element. Perl implements these using
+B<references>—see Camel chapter 9, “Data Structures”.
 
 =item multiple inheritance
 
-The features you got from your mother and father, mixed together
-unpredictably.  (See also L</inheritance>, and L</single
-inheritance>.)  In computer languages (including Perl), the notion
-that a given class may have multiple direct ancestors or L<base
-classes|/base class>.
-
-=back
-
-=head2 N
-
-=over 4
+The features X<multiple inheritance>X<inheritance, multiple>you got from
+your mother and father, mixed together unpredictably. (See also
+B<inheritance> and B<single inheritance>.) In computer languages (including
+Perl), it is the notion that a given class may have multiple direct
+ancestors or B<base classes>.
 
 =item named pipe
 
-A L</pipe> with a name embedded in the L</filesystem> so that it can
-be accessed by two unrelated L<processes|/process>.
+A B<pipe> X<named pipes>X<pipes, names>with a name embedded in the
+B<filesystem> so that it can be accessed by two unrelated B<processes>.
 
 =item namespace
 
-A domain of names.  You needn't worry about whether the names in one
-such domain have been used in another.  See L</package>.
+A domain of X<namespaces, about>names. You needn’t worry about whether the
+names in one such domain have been used in another. See B<package>.
+
+=item NaN
+
+Not a number. X<NaN (not a number)>X<not a number (NaN)>The value Perl uses
+for certain invalid or inexpressible floating-point operations.
 
 =item network address
 
-The most important attribute of a socket, like your telephone's
-telephone number.  Typically an IP address.  See also L</port>.
+The most X<network address>important attribute of a socket, like your
+telephone’s telephone number. Typically an IP address. See also B<port>.
 
 =item newline
 
-A single character that represents the end of a line, with the ASCII
-value of 012 octal under Unix (but 015 on a Mac), and represented by
-C<\n> in Perl strings.  For Windows machines writing text files, and
-for certain physical devices like terminals, the single newline gets
-automatically translated by your C library into a line feed and a
-carriage return, but normally, no translation is done.
+A single X<newline character>X<characters, newline>character that
+represents the end of a line, with the ASCII value of 012 octal under Unix
+(but 015 on a Mac), and represented by C<\n> in Perl strings. For Windows
+machines writing text files, and for certain physical devices like
+terminals, the single newline gets automatically translated by your C
+library into a line feed and a carriage return, but normally, no
+translation is done.
 
 =item NFS
 
-Network File System, which allows you to mount a remote filesystem as
-if it were local.
+Network File System, X<NFS (Network File System)>X<Network File System
+(NFS)>which allows you to mount a remote filesystem as if it were local.
+
+=item normalization
+
+Converting a X<normalization>text string into an alternate but equivalent
+B<canonical> (or compatible) representation that can then be compared for
+equivalence. Unicode recognizes four different normalization forms: NFD,
+NFC, NFKD, and NFKC.
 
 =item null character
 
-A character with the ASCII value of zero.  It's used by C to terminate
-strings, but Perl allows strings to contain a null.
+A character X<null character>X<characters, null>with the numeric value of
+zero. It’s used by C to terminate strings, but Perl allows strings to
+contain a null.
 
 =item null list
 
-A valueless value represented in Perl by C<()>.  It is not really a
-L</LIST>, but an expression that yields C<undef> in L</scalar context> and
-a L</list value> with zero elements in L</list context>.
+A B<list value> with X<null lists>X<lists, null>zero elements, represented
+in Perl by C<()>.
 
 =item null string
 
-A L</string> containing no characters, not to be confused with a
-string containing a L</null character>, which has a positive length
-and is L</true>.
+A B<string> X<null strings>X<strings, null>containing no characters, not to
+be confused with a string containing a B<null character>, which has a
+positive length and is B<true>.
 
 =item numeric context
 
-The situation in which an expression is expected by its surroundings
-(the code calling it) to return a number.  See also L</context> and
-L</string context>.
+The situation X<numeric context>X<context, numeric>in which an expression
+is expected by its surroundings (the code calling it) to return a number.
+See also B<context> and B<string context>.
+
+=item numification
+
+(Sometimes spelled I<nummification> and I<nummify>.) X<numification>Perl lingo
+for implicit conversion into a number; the related verb is I<numify>.
+I<Numification> is intended to rhyme with I<mummification>, and I<numify> with
+I<mummify>. It is unrelated to English I<numen>, I<numina>, I<numinous>. We
+originally forgot the extra I<m> a long time ago, and some people got used to
+our funny spelling, and so just as with C<HTTP_REFERER>’s own missing letter,
+our weird spelling has stuck around.
 
 =item NV
 
-Short for Nevada, no part of which will ever be confused with
-civilization.  NV also means an internal floating-point Numeric Value
-of the type a L</scalar> can hold, not to be confused with an L</IV>.
+Short for Nevada, X<Numeric Value (NV)>X<NV (Numeric Value)>no part of
+which will ever be confused with civilization. NV also means an internal
+floating- point Numeric Value of the type a B<scalar> can hold, not to be
+confused with an B<IV>.
 
 =item nybble
 
-Half a L</byte>, equivalent to one L</hexadecimal> digit, and worth
-four L<bits|/bit>.
-
-=back
-
-=head2 O
-
-=over 4
+Half a B<byte>, X<nybble>equivalent to one B<hexadecimal> digit, and worth
+four B<bits>.
 
 =item object
 
-An L</instance> of a L</class>.  Something that "knows" what
-user-defined type (class) it is, and what it can do because of what
-class it is.  Your program can request an object to do things, but the
-object gets to decide whether it wants to do them or not.  Some
-objects are more accommodating than others.
+An B<instance> X<objects, defined>of a B<class>. Something that “knows”
+what user-defined type (class) it is, and what it can do because of what
+class it is. Your program can request an object to do things, but the
+object gets to decide whether it wants to do them or not. Some objects are
+more accommodating than others.
 
 =item octal
 
-A number in base 8.  Only the digits 0 through 7 are allowed.  Octal
-constants in Perl start with 0, as in 013.  See also the
-L<oct|perlfunc/oct> function.
+A number X<octals>in base 8. Only the digits 0 through 7 are allowed. Octal
+constants in Perl start with 0, as in 013. See also the C<oct> function.
 
 =item offset
 
-How many things you have to skip over when moving from the beginning
-of a string or array to a specific position within it.  Thus, the
-minimum offset is zero, not one, because you don't skip anything to
-get to the first item.
+How many X<offsets in strings>X<strings, offsets in>things you have to skip
+over when moving from the beginning of a string or array to a specific
+position within it. Thus, the minimum offset is zero, not one, because you
+don’t skip anything to get to the first item.
 
 =item one-liner
 
-An entire computer program crammed into one line of text.
+An entire X<one–liner programs>computer program crammed into one line of
+text.
 
 =item open source software
 
-Programs for which the source code is freely available and freely
-redistributable, with no commercial strings attached.  For a more
-detailed definition, see L<http://www.opensource.org/osd.html>.
+Programs X<open source software>for which the source code is freely
+available and freely redistributable, with no commercial strings attached.
+For a more detailed definition, see L<http://www.opensource.org/osd.html>.
 
 =item operand
 
-An L</expression> that yields a L</value> that an L</operator>
-operates on.  See also L</precedence>.
+An B<expression> X<operands (term)>that yields a B<value> that an
+B<operator> operates on. See also B<precedence>.
 
 =item operating system
 
-A special program that runs on the bare machine and hides the gory
-details of managing L<processes|/process> and L<devices|/device>.
+A special X<operating systems, defined>program that runs on the bare
+machine and hides the gory details of managing B<processes> and B<devices>.
 Usually used in a looser sense to indicate a particular culture of
-programming.  The loose sense can be used at varying levels of
-specificity.  At one extreme, you might say that all versions of Unix
-and Unix-lookalikes are the same operating system (upsetting many
-people, especially lawyers and other advocates).  At the other
-extreme, you could say this particular version of this particular
-vendor's operating system is different from any other version of this
-or any other vendor's operating system.  Perl is much more portable
-across operating systems than many other languages.  See also
-L</architecture> and L</platform>.
+programming. The loose sense can be used at varying levels of specificity.
+At one extreme, you might say that all versions of Unix and Unix-lookalikes
+are the same operating system (upsetting many people, especially lawyers
+and other advocates). At the other extreme, you could say this particular
+version of this particular vendor’s operating system is different from any
+other version of this or any other vendor’s operating system. Perl is much
+more portable across operating systems than many other languages. See also
+B<architecture> and B<platform>.
 
 =item operator
 
-A gizmo that transforms some number of input values to some number of
-output values, often built into a language with a special syntax or
-symbol.  A given operator may have specific expectations about what
-L<types|/type> of data you give as its arguments
-(L<operands|/operand>) and what type of data you want back from it.
+A gizmo X<operators, about>that transforms some number of input values to
+some number of output values, often built into a language with a special
+syntax or symbol. A given operator may have specific expectations about
+what B<types> of data you give as its arguments (B<operands>) and what type
+of data you want back from it.
 
 =item operator overloading
 
-A kind of L</overloading> that you can do on built-in
-L<operators|/operator> to make them work on L<objects|/object> as if
-the objects were ordinary scalar values, but with the actual semantics
-supplied by the object class.  This is set up with the L<overload>
-L</pragma>.
+A kind X<operator overloading, about>X<overloading, operator>of
+B<overloading> that you can do on built-in B<operators> to make them work
+on B<objects> as if the objects were ordinary scalar values, but with the
+actual semantics supplied by the object class. This is set up with the
+overload B<pragma>—see Camel chapter 13, “Overloading”.
 
 =item options
 
-See either L<switches|/switch> or L</regular expression modifier>.
+See X<options>either B<switches> or B<regular expression modifiers>.
 
 =item ordinal
 
-Another name for L</code point>
+An X<ordinals (term)>abstract character’s integer value. Same thing as
+B<codepoint>.
 
 =item overloading
 
-Giving additional meanings to a symbol or construct.  Actually, all
-languages do overloading to one extent or another, since people are
-good at figuring out things from L</context>.
+Giving X<overloading, defined>additional meanings to a symbol or construct.
+Actually, all languages do overloading to one extent or another, since
+people are good at figuring out things from B<context>.
 
 =item overriding
 
-Hiding or invalidating some other definition of the same name.  (Not
-to be confused with L</overloading>, which adds definitions that must
-be disambiguated some other way.) To confuse the issue further, we use
-the word with two overloaded definitions: to describe how you can
-define your own L</subroutine> to hide a built-in L</function> of the
-same name (see L<perlsub/Overriding Built-in Functions>) and to
-describe how you can define a replacement L</method> in a L</derived
-class> to hide a L</base class>'s method of the same name (see
-L<perlobj>).
+Hiding or X<overriding, defined>invalidating some other definition of the
+same name. (Not to be confused with B<overloading>, which adds definitions
+that must be disambiguated some other way.) To confuse the issue further,
+we use the word with two overloaded definitions: to describe how you can
+define your own B<subroutine> to hide a built-in B<function> of the same
+name (see the section “Overriding Built-in Functions” in Camel chapter 11,
+“Modules”), and to describe how you can define a replacement B<method> in a
+B<derived class> to hide a B<base class>’s method of the same name (see
+Camel chapter 12, “Objects”).
 
 =item owner
 
-The one user (apart from the superuser) who has absolute control over
-a L</file>.  A file may also have a L</group> of users who may
-exercise joint ownership if the real owner permits it.  See
-L</permission bits>.
-
-=back
-
-=head2 P
-
-=over 4
+The one X<ownership, file>X<files, ownership of>user (apart from the
+superuser) who has absolute control over a B<file>. A file may also have a
+B<group> of users who may exercise joint ownership if the real owner
+permits it. See B<permission bits>.
 
 =item package
 
-A L</namespace> for global L<variables|/variable>,
-L<subroutines|/subroutine>, and the like, such that they can be kept
-separate from like-named L<symbols|/symbol> in other namespaces.  In a
-sense, only the package is global, since the symbols in the package's
-symbol table are only accessible from code compiled outside the
-package by naming the package.  But in another sense, all package
-symbols are also globals--they're just well-organized globals.
+A B<namespace> for X<packages, defined>global B<variables>, B<subroutines>,
+and the like, such that they can be kept separate from like-named
+B<symbols> in other namespaces. In a sense, only the package is global,
+since the symbols in the package’s symbol table are only accessible from
+code B<compiled> outside the package by naming the package. But in another
+sense, all package symbols are also globals—they’re just well-organized
+globals.
 
 =item pad
 
-Short for L</scratchpad>.
+Short X<pads (scratchpads)>for B<scratchpad>.
 
 =item parameter
 
-See L</argument>.
+SeeX<parameters> B<argument>.
 
 =item parent class
 
-See L</base class>.
+SeeX<parent classes>X<classes, parent> B<base class>.
 
 =item parse tree
 
-See L</syntax tree>.
+SeeX<parse tree> B<syntax tree>.
 
 =item parsing
 
-The subtle but sometimes brutal art of attempting to turn your
-possibly malformed program into a valid L</syntax tree>.
+The X<parsing, about>subtle but sometimes brutal art of attempting to turn
+your possibly malformed program into a valid B<syntax tree>.
 
 =item patch
 
-To fix by applying one, as it were.  In the realm of hackerdom, a
-listing of the differences between two versions of a program as might
-be applied by the I<patch>(1) program when you want to fix a bug or
-upgrade your old version.
+To X<patches>fix by applying one, as it were. In the realm of hackerdom, a
+listing of the differences between two versions of a program as might be
+applied by the B<patch>(1) program when you want to fix a bug or upgrade
+your old version.
 
 =item PATH
 
-The list of L<directories|/directory> the system searches to find a
-program you want to L</execute>.  The list is stored as one of your
-L<environment variables|/environment variable>, accessible in Perl as
-C<$ENV{PATH}>.
+The X<PATH environment variable>X<variables, environment>list of
+B<directories> the system searches to find a program you want to
+B<execute>.  The list is stored as one of your B<environment variables>,
+accessible in Perl as C<$ENV{PATH}>.
 
 =item pathname
 
-A fully qualified filename such as I</usr/bin/perl>.  Sometimes
-confused with L</PATH>.
+A X<pathname>fully qualified filename such as I</usr/bin/perl>. Sometimes
+confused with C<PATH>.
 
 =item pattern
 
-A template used in L</pattern matching>.
+A X<patterns, defined>template used in B<pattern matching>.
 
 =item pattern matching
 
-Taking a pattern, usually a L</regular expression>, and trying the
-pattern various ways on a string to see whether there's any way to
-make it fit.  Often used to pick interesting tidbits out of a file.
+Taking a X<pattern matching, about>pattern, usually a B<regular
+expression>, and trying the pattern various ways on a string to see whether
+there’s any way to make it fit. Often used to pick interesting tidbits out
+of a file.
+
+=item PAUSE
+
+The X<Perl Authors Upload SErver (PAUSE)>X<PAUSE (Perl Authors Upload
+SErver)>Perl Authors Upload SErver (L<http://pause.perl.org>), the gateway
+for B<modules> on their way to B<CPAN>.
+
+=item Perl mongers
+
+A X<Perl mongers>X<mongers, Perl>Perl user group, taking the form of its
+name from the New York Perl mongers, the first Perl user group. Find one
+near you at L<http://www.pm.org>.
 
 =item permission bits
 
-Bits that the L</owner> of a file sets or unsets to allow or disallow
-access to other people.  These flag bits are part of the L</mode> word
-returned by the L<stat|perlfunc/stat> built-in when you ask about a
-file.  On Unix systems, you can check the I<ls>(1) manpage for more
+Bits X<permission bits>X<bits, permission>that the B<owner> of a file sets
+or unsets to allow or disallow access to other people. These flag bits are
+part of the B<mode> word returned by the C<stat> built-in when you ask
+about a file. On Unix systems, you can check the I<ls>(1) manpage for more
 information.
 
 =item Pern
 
-What you get when you do C<Perl++> twice.  Doing it only once will
-curl your hair.  You have to increment it eight times to shampoo your
-hair.  Lather, rinse, iterate.
+What you get X<Pern (term)>when you do C<Perl++> twice. Doing it only once
+will curl your hair. You have to increment it eight times to shampoo your
+hair. Lather, rinse, iterate.
 
 =item pipe
 
-A direct L</connection> that carries the output of one L</process> to
-the input of another without an intermediate temporary file.  Once the
-pipe is set up, the two processes in question can read and write as if
-they were talking to a normal file, with some caveats.
+A X<pipes, defined>direct B<connection> that carries the output of one
+B<process> to the input of another without an intermediate temporary file.
+Once the pipe is set up, the two processes in question can read and write
+as if they were talking to a normal file, with some caveats.
 
 =item pipeline
 
-A series of L<processes|/process> all in a row, linked by
-L<pipes|/pipe>, where each passes its output stream to the next.
+A X<pipeline>series of B<processes> all in a row, linked by B<pipes>, where
+each passes its output stream to the next.
 
 =item platform
 
-The entire hardware and software context in which a program runs.  A
- program written in a platform-dependent language might break if you
-change any of: machine, operating system, libraries, compiler, or
-system configuration.  The I<perl> interpreter has to be compiled
-differently for each platform because it is implemented in C, but
-programs written in the Perl language are largely
-platform-independent.
+The X<platforms, defined>entire hardware and software context in which a
+program runs. A program written in a platform-dependent language might
+break if you change any of the following: machine, operating system,
+libraries, compiler, or system configuration. The I<perl> interpreter has
+to be B<compiled> differently for each platform because it is implemented
+in C, but programs written in the Perl language are largely platform
+independent.
 
 =item pod
 
-The markup used to embed documentation into your Perl code.  See
-L<perlpod>.
+The X<pod (plain old documentation), about>X<plain old documentation>markup
+used to embed documentation into your Perl code. Pod stands for “Plain old
+documentation”. See Camel chapter 23, “Plain Old Documentation”.
+
+=item pod command
+
+A X<pod commands>X<commands, pod>sequence, such as C<=head1>, that denotes
+the start of a B<pod> section.
 
 =item pointer
 
-A L</variable> in a language like C that contains the exact memory
-location of some other item.  Perl handles pointers internally so you
-don't have to worry about them.  Instead, you just use symbolic
-pointers in the form of L<keys|/key> and L</variable> names, or L<hard
-references|/hard reference>, which aren't pointers (but act like
-pointers and do in fact contain pointers).
+A B<variable> X<pointers>in a language like C that contains the exact
+memory location of some other item. Perl handles pointers internally so you
+don’t have to worry about them. Instead, you just use symbolic pointers in
+the form of B<keys> and B<variable> names, or B<hard references>, which
+aren’t pointers (but act like pointers and do in fact contain pointers).
 
 =item polymorphism
 
-The notion that you can tell an L</object> to do something generic,
-and the object will interpret the command in different ways depending
-on its type.  [E<lt>Gk many shapes]
+The notion X<polymorphism>that you can tell an B<object> to do something
+generic, and the object will interpret the command in different ways
+depending on its type. [E<lt> Greek πολυ- + μορϕή, many forms.]
 
 =item port
 
-The part of the address of a TCP or UDP socket that directs packets to
-the correct process after finding the right machine, something like
-the phone extension you give when you reach the company operator.
-Also, the result of converting code to run on a different platform
-than originally intended, or the verb denoting this conversion.
+The X<ports (term)>part of the address of a TCP or UDP socket that directs
+packets to the correct process after finding the right machine, something
+like the phone extension you give when you reach the company operator. Also
+the result of converting code to run on a different platform than
+originally intended, or the verb denoting this conversion.
 
 =item portable
 
-Once upon a time, C code compilable under both BSD and SysV.  In
-general, code that can be easily converted to run on another
-L</platform>, where "easily" can be defined however you like, and
-usually is.  Anything may be considered portable if you try hard
-enough.  See I<mobile home> or I<London Bridge>.
+Once X<portability, about>upon a time, C code compilable under both BSD and
+SysV. In general, code that can be easily converted to run on another
+B<platform>, where “easily” can be defined however you like, and usually
+is.  Anything may be considered portable if you try hard enough, such as a
+mobile home or London Bridge.
 
 =item porter
 
-Someone who "carries" software from one L</platform> to another.
-Porting programs written in platform-dependent languages such as C can
-be difficult work, but porting programs like Perl is very much worth
-the agony.
+Someone X<porters>who “carries” software from one B<platform> to another.
+Porting programs written in platform-dependent languages such as C can be
+difficult work, but porting programs like Perl is very much worth the
+agony.
+
+=item possessive
+
+Said of X<possessive (term)>quantifiers and groups in patterns that refuse
+to give up anything once they’ve gotten their mitts on it. Catchier and
+easier to say than the even more formal I<nonbacktrackable>.
 
 =item POSIX
 
-The Portable Operating System Interface specification.
+The X<Portable Operating System Interface (POSIX), about>X<POSIX (Portable
+Operating System Interface), about>Portable Operating System Interface
+specification.
 
 =item postfix
 
-An L</operator> that follows its L</operand>, as in C<$x++>.
+An B<operator> X<postfix operator>that follows its B<operand>, as in
+C<$x++>.
 
 =item pp
 
-An internal shorthand for a "push-pop" code, that is, C code
-implementing Perl's stack machine.
+An X<pp (push–pop) code>X<push–pop (pp) code>internal shorthand for a
+“push- pop” code; that is, C code implementing Perl’s stack machine.
 
 =item pragma
 
-A standard module whose practical hints and suggestions are received
-(and possibly ignored) at compile time.  Pragmas are named in all
-lowercase.
+A X<pragmas, about>X<modules>standard module whose practical hints and
+suggestions are received (and possibly ignored) at compile time. Pragmas
+are named in all lowercase.
 
 =item precedence
 
-The rules of conduct that, in the absence of other guidance, determine
-what should happen first.  For example, in the absence of parentheses,
-you always do multiplication before addition.
+The X<precedence rules, about>X<operators, precedence rules>rules of
+conduct that, in the absence of other guidance, determine what should
+happen first.  For example, in the absence of parentheses, you always do
+multiplication before addition.
 
 =item prefix
 
-An L</operator> that precedes its L</operand>, as in C<++$x>.
+An B<operator> X<prefix operators>that precedes its B<operand>, as in
+C<++$x>.
 
 =item preprocessing
 
-What some helper L</process> did to transform the incoming data into a
-form more suitable for the current process.  Often done with an
-incoming L</pipe>.  See also L</C preprocessor>.
+What X<preprocessing>some helper B<process> did to transform the incoming
+data into a form more suitable for the current process. Often done with an
+incoming B<pipe>. See also B<C preprocessor>.
+
+=item primary maintainer
+
+The X<primary maintainer>author that PAUSE allows to assign B<co-maintainer> 
+permissions to a B<namespace>. A primary maintainer can give up this
+distinction by assigning it to another PAUSE author. See Camel chapter 19,
+“CPAN”.
 
 =item procedure
 
-A L</subroutine>.
+AX<procedures, defined> B<subroutine>.
 
 =item process
 
-An instance of a running program.  Under multitasking systems like
-Unix, two or more separate processes could be running the same program
-independently at the same time--in fact, the L<fork|perlfunc/fork>
-function is designed to bring about this happy state of affairs.
-Under other operating systems, processes are sometimes called
-"threads", "tasks", or "jobs", often with slight nuances in meaning.
+An X<processes, defined>instance of a running program. Under multitasking
+systems like Unix, two or more separate processes could be running the same
+program independently at the same time—in fact, the C<fork> function is
+designed to bring about this happy state of affairs. Under other operating
+systems, processes are sometimes called “threads”, “tasks”, or “jobs”,
+often with slight nuances in meaning.
+
+=item program
+
+See B<script>.
 
 =item program generator
 
-A system that algorithmically writes code for you in a high-level
-language.  See also L</code generator>.
+A system X<program generators>that algorithmically writes code for you in a
+high-level language. See also B<code generator>.
 
 =item progressive matching
 
-L<Pattern matching|/pattern matching> that picks up where it left off before.
+B<Pattern matching> X<progressive matching>X<pattern matching, progressive
+matching> matching>that picks up where it left off before.
 
 =item property
 
-See either L</instance variable> or L</character property>.
+See X<property>either B<instance variable> or B<character property>.
 
 =item protocol
 
-In networking, an agreed-upon way of sending messages back and forth
-so that neither correspondent will get too confused.
+In X<protocols (term)>networking, an agreed-upon way of sending messages
+back and forth so that neither correspondent will get too confused.
 
 =item prototype
 
-An optional part of a L</subroutine> declaration telling the Perl
-compiler how many and what flavor of arguments may be passed as
-L</actual arguments>, so that you can write subroutine calls that
-parse much like built-in functions.  (Or don't parse, as the case may
-be.)
+An X<prototypes, about>optional part of a B<subroutine> declaration telling
+the Perl compiler how many and what flavor of arguments may be passed as
+B<actual arguments>, so you can write subroutine calls that parse much like
+built-in functions. (Or don’t parse, as the case may be.)
 
 =item pseudofunction
 
-A construct that sometimes looks like a function but really isn't.
-Usually reserved for L</lvalue> modifiers like L<my|perlfunc/my>, for
-L</context> modifiers like L<scalar|perlfunc/scalar>, and for the
-pick-your-own-quotes constructs, C<q//>, C<qq//>, C<qx//>, C<qw//>,
-C<qr//>, C<m//>, C<s///>, C<y///>, and C<tr///>.
+A X<pseudofunctions>X<constructs, pseudofunctions>X<functions,
+pseudofunctions>construct that sometimes looks like a function but really
+isn’t. Usually reserved for B<lvalue> modifiers like C<my>, for B<context>
+modifiers like C<scalar>, and for the pick-your-own-quotes constructs,
+C<q//>, C<qq//>, C<qx//>, C<qw//>, C<qr//>, C<m//>, C<s///>, C<y///>, and
+C<tr///>.
 
 =item pseudohash
 
-A reference to an array whose initial element happens to hold a
-reference to a hash.  You can treat a pseudohash reference as either
-an array reference or a hash reference.
+Formerly, a reference X<pseudohashes>X<hashes, pseudohashes>to an array
+whose initial element happens to hold a reference to a hash. You used to be
+able to treat a pseudohash reference as either an array reference or a hash
+reference. Pseduohashes are no longer supported.
 
 =item pseudoliteral
 
-An L</operator> that looks something like a L</literal>, such as the
-output-grabbing operator, C<`>I<C<command>>C<`>.
+An B<operator> X<pseudoliterals>XC<that looks something like a B<literal>,
+such as the output-grabbing operator, <literal
+moreinfo="none">`>I<C<command>>C<`>.
 
 =item public domain
 
-Something not owned by anybody.  Perl is copyrighted and is thus
-I<not> in the public domain--it's just L</freely available> and
-L</freely redistributable>.
+Something X<public domain>not owned by anybody. Perl is copyrighted and is
+thus I<not> in the public domain—it’s just B<freely available> and B<freely
+redistributable>.
 
 =item pumpkin
 
-A notional "baton" handed around the Perl community indicating who is
-the lead integrator in some arena of development.
+A X<pumpkin (term)>notional “baton” handed around the Perl community
+indicating who is the lead integrator in some arena of development.
 
 =item pumpking
 
-A L</pumpkin> holder, the person in charge of pumping the pump, or at
-least priming it.  Must be willing to play the part of the Great
+A B<X<pumpking>pumpkin> holder, the person in charge of pumping the pump,
+or at least priming it. Must be willing to play the part of the Great
 Pumpkin now and then.
 
 =item PV
 
-A "pointer value", which is Perl Internals Talk for a C<char*>.
-
-=back
-
-=head2 Q
-
-=over 4
+A “X<PV (pointer value)>X<pointer value (PV)>pointer value”, which is Perl
+Internals Talk for a C<char*>.
 
 =item qualified
 
-Possessing a complete name.  The symbol C<$Ent::moot> is qualified;
-C<$moot> is unqualified.  A fully qualified filename is specified from
-the top-level directory.
+Possessing a X<qualified (term)>complete name. The symbol C<$Ent::moot> is
+qualified; C<$moot> is unqualified. A fully qualified filename is specified
+from the top-level directory.
 
 =item quantifier
 
-A component of a L</regular expression> specifying how many times the
-foregoing L</atom> may occur.
+A X<quantifiers, about>component of a B<regular expression> specifying how
+many times the foregoing B<atom> may occur.
 
-=back
+=item race condition
 
-=head2 R
-
-=over 4
+A X<race conditions, defined>race condition exists when the result of
+several interrelated events depends on the ordering of those events, but
+that order cannot be guaranteed due to nondeterministic timing effects. If
+two or more programs, or parts of the same program, try to go through the
+same series of events, one might interrupt the work of the other. This is a
+good way to find an B<exploit>.
 
 =item readable
 
-With respect to files, one that has the proper permission bit set to
-let you access the file.  With respect to computer programs, one
-that's written well enough that someone has a chance of figuring out
-what it's trying to do.
+With X<readable (term)>respect to files, one that has the proper permission
+bit set to let you access the file. With respect to computer programs, one
+that’s written well enough that someone has a chance of figuring out what
+it’s trying to do.
 
 =item reaping
 
-The last rites performed by a parent L</process> on behalf of a
-deceased child process so that it doesn't remain a L</zombie>.  See
-the L<wait|perlfunc/wait> and L<waitpid|perlfunc/waitpid> function
-calls.
+The last X<reaping zombie processes>rites performed by a parent B<process>
+on behalf of a deceased child process so that it doesn’t remain a
+B<zombie>.  See the C<wait> and C<waitpid> function calls.
 
 =item record
 
-A set of related data values in a L</file> or L</stream>, often
-associated with a unique L</key> field.  In Unix, often commensurate
-with a L</line>, or a blank-line-terminated set of lines (a
-"paragraph").  Each line of the I</etc/passwd> file is a record, keyed
-on login name, containing information about that user.
+A set of X<records, defined>related data values in a B<file> or B<stream>,
+often associated with a unique B<key> field. In Unix, often commensurate
+with a B<line>, or a blank-line–terminated set of lines (a “paragraph”).
+Each line of the I</etc/passwd> file is a record, keyed on login name,
+containing information about that user.
 
 =item recursion
 
-The art of defining something (at least partly) in terms of itself,
-which is a naughty no-no in dictionaries but often works out okay in
-computer programs if you're careful not to recurse forever, which is
-like an infinite loop with more spectacular failure modes.
+The art of X<recursion, defined>defining something (at least partly) in
+terms of itself, which is a naughty no-no in dictionaries but often works
+out okay in computer programs if you’re careful not to recurse forever
+(which is like an infinite loop with more spectacular failure modes).
 
 =item reference
 
-Where you look to find a pointer to information somewhere else.  (See
-L</indirection>.)  References come in two flavors, L<symbolic
-references|/symbolic reference> and L<hard references|/hard
-reference>.
+Where you X<references, about>look to find a pointer to information
+somewhere else. (See B<indirection>.) References come in two flavors:
+B<symbolic references> and B<hard references>.
 
 =item referent
 
-Whatever a reference refers to, which may or may not have a name.
-Common types of referents include scalars, arrays, hashes, and
+Whatever a X<referents, defined>reference refers to, which may or may not
+have a name. Common types of referents include scalars, arrays, hashes, and
 subroutines.
 
 =item regex
 
-See L</regular expression>.
+See B<regular expression>.
 
 =item regular expression
 
-A single entity with various interpretations, like an elephant.  To a
-computer scientist, it's a grammar for a little language in which some
-strings are legal and others aren't.  To normal people, it's a pattern
-you can use to find what you're looking for when it varies from case
-to case.  Perl's regular expressions are far from regular in the
-theoretical sense, but in regular use they work quite well.  Here's a
-regular expression: C</Oh s.*t./>.  This will match strings like "C<Oh
-say can you see by the dawn's early light>" and "C<Oh sit!>".  See
-L<perlre>.
+A single X<regular expressions, defined>entity with various
+interpretations, like an elephant. To a computer scientist, it’s a grammar
+for a little language in which some strings are legal and others aren’t. To
+normal people, it’s a pattern you can use to find what you’re looking for
+when it varies from case to case. Perl’s regular expressions are far from
+regular in the theoretical sense, but in regular use they work quite well.
+Here’s a regular expression: C</Oh s.*t./>. This will match strings like
+“C<Oh say can you see by the dawn's early light>” and “C<Oh sit!>”. See
+Camel chapter 5, “Pattern Matching”.
 
 =item regular expression modifier
 
-An option on a pattern or substitution, such as C</i> to render the
-pattern case insensitive.  See also L</cloister>.
+An option on a X<regular expression modifiers>X<modifiers, regular
+expression>pattern or substitution, such as C</i> to render the pattern
+case- insensitive.
 
 =item regular file
 
-A L</file> that's not a L</directory>, a L</device>, a named L</pipe>
-or L</socket>, or a L</symbolic link>.  Perl uses the C<-f> file test
-operator to identify regular files.  Sometimes called a "plain" file.
+A B<file> that’s X<regular files>X<files, regular>not a B<directory>, a
+B<device>, a named B<pipe> or B<socket>, or a B<symbolic link>. Perl uses
+the C<–f> file test operator to identify regular files. Sometimes called a
+“plain” file.
 
 =item relational operator
 
-An L</operator> that says whether a particular ordering relationship
-is L</true> about a pair of L<operands|/operand>.  Perl has both
-numeric and string relational operators.  See L</collating sequence>.
+An B<operator> that X<relational operators>says whether a particular
+ordering relationship is B<true> about a pair of B<operands>. Perl has both
+numeric and string relational operators. See B<collating sequence>.
 
 =item reserved words
 
-A word with a specific, built-in meaning to a L</compiler>, such as
-C<if> or L<delete|perlfunc/delete>.  In many languages (not Perl),
-it's illegal to use reserved words to name anything else.  (Which is
-why they're reserved, after all.)  In Perl, you just can't use them to
-name L<labels|/label> or L<filehandles|/filehandle>.  Also called
-"keywords".
-
-=item restricted hash
-
-A L</hash> with a closed set of allowed keys. See L<Hash::Util>.
+A word with a X<reserved words>X<keywords (term)>specific, built-in meaning
+to a B<compiler>, such as C<if> or C<delete>. In many languages (not Perl),
+it’s illegal to use reserved words to name anything else. (Which is why
+they’re reserved, after all.) In Perl, you just can’t use them to name
+B<labels> or B<filehandles>. Also called “keywords”.
 
 =item return value
 
-The L</value> produced by a L</subroutine> or L</expression> when
-evaluated.  In Perl, a return value may be either a L</list> or a
-L</scalar>.
+The B<value> produced X<return values>X<values, return>by a B<subroutine>
+or B<expression> when evaluated. In Perl, a return value may be either a
+B<list> or a B<scalar>.
 
 =item RFC
 
-Request For Comment, which despite the timid connotations is the name
-of a series of important standards documents.
+Request For Comment, X<Request For Comment (RFC)>X<RFC (Request For
+Comment)>which despite the timid connotations is the name of a series of
+important standards documents.
 
 =item right shift
 
-A L</bit shift> that divides a number by some power of 2.
+A B<bit shift> X<right shift (E<gt>E<gt>) bit operator>X<bit–shift
+operators, right shift>X<E<gt>E<gt> (right shift) bit operator>that divides
+a number by some power of 2.
+
+=item role
+
+A name X<roles (term)>for a concrete set of behaviors. A role is a way to
+add behavior to a class without inheritance.
 
 =item root
 
-The superuser (UID == 0).  Also, the top-level directory of the
-filesystem.
+The X<root (term)>superuser (C<UID> == 0). Also the top-level directory of
+the filesystem.
 
 =item RTFM
 
-What you are told when someone thinks you should Read The Fine Manual.
+What X<RTFM acronym>you are told when someone thinks you should Read The
+Fine Manual.
 
 =item run phase
 
-Any time after Perl starts running your main program.  See also
-L</compile phase>.  Run phase is mostly spent in L</run time> but may
-also be spent in L</compile time> when L<require|perlfunc/require>,
-L<do|perlfunc/do> C<FILE>, or L<eval|perlfunc/eval> C<STRING>
-operators are executed or when a substitution uses the C</ee>
-modifier.
+Any X<run phase, defined>time after Perl starts running your main program.
+See also B<compile phase>. Run phase is mostly spent in B<runtime> but may
+also be spent in B<compile time> when C<require>, C<do> I<C<FILE>>, or
+C<eval> I<C<STRING>> operators are executed, or when a substitution uses
+the C</ee> modifier.
 
-=item run time
+=item runtime
 
-The time when Perl is actually doing what your code says to do, as
-opposed to the earlier period of time when it was trying to figure out
-whether what you said made any sense whatsoever, which is L</compile
-time>.
+The time X<runtime (term), defined>when Perl is actually doing what your
+code says to do, as opposed to the earlier period of time when it was
+trying to figure out whether what you said made any sense whatsoever, which
+is B<compile time>.
 
-=item run-time pattern
+=item runtime pattern
 
-A pattern that contains one or more variables to be interpolated
-before parsing the pattern as a L</regular expression>, and that
-therefore cannot be analyzed at compile time, but must be re-analyzed
-each time the pattern match operator is evaluated.  Run-time patterns
-are useful but expensive.
+A X<runtime patterns>X<patterns, runtime>pattern that contains one or more
+variables to be interpolated before parsing the pattern as a B<regular
+expression>, and that therefore cannot be analyzed at compile time, but
+must be reanalyzed each time the pattern match operator is evaluated.
+Runtime patterns are useful but expensive.
 
 =item RV
 
-A recreational vehicle, not to be confused with vehicular recreation.
-RV also means an internal Reference Value of the type a L</scalar> can
-hold.  See also L</IV> and L</NV> if you're not confused yet.
+A X<Reference Value (RV)>X<RV (Reference Value)>recreational vehicle, not
+to be confused with vehicular recreation. RV also means an internal
+Reference Value of the type a B<scalar> can hold. See also B<IV> and B<NV>
+if you’re not confused yet.
 
 =item rvalue
 
-A L</value> that you might find on the right side of an
-L</assignment>.  See also L</lvalue>.
+A B<value> that X<rvalue (term)>X<values, rvalue>you might find on the
+right side of an B<assignment>. See also B<lvalue>.
 
-=back
+=item sandbox
 
-=head2 S
-
-=over 4
+A X<sandbox, defined>walled off area that’s not supposed to affect beyond
+its walls. You let kids play in the sandbox instead of running in the road.
+See Camel chapter 20, “Security”.
 
 =item scalar
 
-A simple, singular value; a number, L</string>, or L</reference>.
+A X<scalars, defined>simple, singular value; a number, B<string>, or
+B<reference>.
 
 =item scalar context
 
-The situation in which an L</expression> is expected by its
-surroundings (the code calling it) to return a single L</value> rather
-than a L</list> of values.  See also L</context> and L</list context>.
-A scalar context sometimes imposes additional constraints on the
-return value--see L</string context> and L</numeric context>.
-Sometimes we talk about a L</Boolean context> inside conditionals, but
-this imposes no additional constraints, since any scalar value,
-whether numeric or L</string>, is already true or false.
+The X<scalar context, about>X<context, scalar>situation in which an
+B<expression> is expected by its surroundings (the code calling it) to
+return a single B<value> rather than a B<list> of values. See also
+B<context> and B<list context>. A scalar context sometimes imposes
+additional constraints on the return value—see B<string context> and
+B<numeric context>. Sometimes we talk about a B<Boolean context> inside
+conditionals, but this imposes no additional constraints, since any scalar
+value, whether numeric or B<string>, is already true or false.
 
 =item scalar literal
 
-A number or quoted L</string>--an actual L</value> in the text of your
-program, as opposed to a L</variable>.
+A X<scalar literals>X<literals, scalar>number or quoted B<string>—an actual
+B<value> in the text of your program, as opposed to a B<variable>.
 
 =item scalar value
 
-A value that happens to be a L</scalar> as opposed to a L</list>.
+A X<scalar values, about>X<values, scalar>X<SV>value that happens to be a
+B<scalar> as opposed to a B<list>.
 
 =item scalar variable
 
-A L</variable> prefixed with C<$> that holds a single value.
+A B<variable> X<scalar variables, defined>X<variables, scalar>prefixed with
+C<$> that holds a single value.
 
 =item scope
 
-How far away you can see a variable from, looking through one.  Perl
-has two visibility mechanisms: it does L</dynamic scoping> of
-L<local|perlfunc/local> L<variables|/variable>, meaning that the rest
-of the L</block>, and any L<subroutines|/subroutine> that are called
-by the rest of the block, can see the variables that are local to the
-block.  Perl does L</lexical scoping> of L<my|perlfunc/my> variables,
-meaning that the rest of the block can see the variable, but other
-subroutines called by the block I<cannot> see the variable.
+From X<scopes, defined>how far away you can see a variable, looking through
+one. Perl has two visibility mechanisms. It does B<dynamic scoping> of
+C<local> B<variables>, meaning that the rest of the B<block>, and any
+B<subroutines> that are called by the rest of the block, can see the
+variables that are local to the block. Perl does B<lexical scoping> of
+C<my> variables, meaning that the rest of the block can see the variable,
+but other subroutines called by the block I<cannot> see the variable.
 
 =item scratchpad
 
-The area in which a particular invocation of a particular file or
-subroutine keeps some of its temporary values, including any lexically
-scoped variables.
+The X<scratchpads>area in which a particular invocation of a particular
+file or subroutine keeps some of its temporary values, including any
+lexically scoped variables.
 
 =item script
 
-A text L</file> that is a program intended to be L<executed|/execute>
-directly rather than L<compiled|/compiler> to another form of file
-before execution.  Also, in the context of L</Unicode>, a writing
-system for a particular language or group of languages, such as Greek,
-Bengali, or Klingon.
+A X<scripts (term)>X<programs, defined>text B<file> that is a program
+intended to be B<executed> directly rather than B<compiled> to another form
+of file before B<execution>.
+
+Also, in the context of B<Unicode>, a writing system for a particular
+language or group of languages, such as Greek, Bengali, or Tengwar.
 
 =item script kiddie
 
-A L</cracker> who is not a L</hacker>, but knows just enough to run
-canned scripts.  A cargo-cult programmer.
+A B<cracker> X<script kiddie>who is not a B<hacker> but knows just enough
+to run canned scripts. A B<cargo-cult> programmer.
 
 =item sed
 
-A venerable Stream EDitor from which Perl derives some of its ideas.
+A venerable Stream EDitor X<sed (Stream EDitor)>X<Stream EDitor (sed)>from
+which Perl derives some of its ideas.
 
 =item semaphore
 
-A fancy kind of interlock that prevents multiple L<threads|/thread> or
-L<processes|/process> from using up the same resources simultaneously.
+A fancy X<semaphore>kind of interlock that prevents multiple B<threads> or
+B<processes> from using up the same resources simultaneously.
 
 =item separator
 
-A L</character> or L</string> that keeps two surrounding strings from
-being confused with each other.  The L<split|perlfunc/split> function
-works on separators.  Not to be confused with L<delimiters|/delimiter>
-or L<terminators|/terminator>.  The "or" in the previous sentence
-separated the two alternatives.
+A B<character> X<separators>X<characters, separators>X<strings,
+separators>or B<string> that keeps two surrounding strings from being
+confused with each other. The C<split> function X<split function,
+separators and>works on separators. Not to be confused with B<delimiters>
+or B<terminators>. The “or” in the previous sentence separated the two
+alternatives.
 
 =item serialization
 
-Putting a fancy L</data structure> into linear order so that it can be
-stored as a L</string> in a disk file or database or sent through a
-L</pipe>.  Also called marshalling.
+Putting a X<serialization>X<marshalling (term)>fancy B<data structure> into
+linear order so that it can be stored as a B<string> in a disk file or
+database, or sent through a B<pipe>. Also called marshalling.
 
 =item server
 
-In networking, a L</process> that either advertises a L</service> or
-just hangs around at a known location and waits for L<clients|/client>
-who need service to get in touch with it.
+In networking, X<servers, defined>X<processes, server>a B<process> that
+either advertises a B<service> or just hangs around at a known location and
+waits for B<clients> who need service to get in touch with it.
 
 =item service
 
-Something you do for someone else to make them happy, like giving them
-the time of day (or of their life).  On some machines, well-known
-services are listed by the L<getservent|perlfunc/getservent> function.
+Something X<services (term)>you do for someone else to make them happy,
+like giving them the time of day (or of their life). On some machines,
+well-known services are listed by theX<getservent function> C<getservent>
+function.
 
 =item setgid
 
-Same as L</setuid>, only having to do with giving away L</group>
-privileges.
+Same as B<setuid>, X<setgid program, about>only having to do with giving
+away B<group> privileges.
 
 =item setuid
 
-Said of a program that runs with the privileges of its L</owner>
-rather than (as is usually the case) the privileges of whoever is
-running it.  Also describes the bit in the mode word (L</permission
-bits>) that controls the feature.  This bit must be explicitly set by
-the owner to enable this feature, and the program must be carefully
-written not to give away more privileges than it ought to.
+Said of a program X<setuid program, about>that runs with the privileges of
+its B<owner> rather than (as is usually the case) the privileges of whoever
+is running it. Also describes the bit in the mode word (B<permission bits>)
+that controls the feature. This bit must be explicitly set by the owner to
+enable this feature, and the program must be carefully written not to give
+away more privileges than it ought to.
 
 =item shared memory
 
-A piece of L</memory> accessible by two different
-L<processes|/process> who otherwise would not see each other's memory.
+A piece of B<memory> X<shared memory>X<memory, shared>accessible by two
+different B<processes> who otherwise would not see each other’s memory.
 
 =item shebang
 
-Irish for the whole McGillicuddy.  In Perl culture, a portmanteau of
-"sharp" and "bang", meaning the C<#!> sequence that tells the system
-where to find the interpreter.
+Irish for the X<shebang (term)>whole McGillicuddy. In Perl culture, a
+portmanteau of “sharp” and “bang”, meaning the C<#!> sequence that tells
+the system where to find the interpreter.
 
 =item shell
 
-A L</command>-line L</interpreter>.  The program that interactively
-gives you a prompt, accepts one or more L<lines|/line> of input, and
-executes the programs you mentioned, feeding each of them their proper
-L<arguments|/argument> and input data.  Shells can also execute
-scripts containing such commands.  Under Unix, typical shells include
-the Bourne shell (I</bin/sh>), the C shell (I</bin/csh>), and the Korn
-shell (I</bin/ksh>).  Perl is not strictly a shell because it's not
-interactive (although Perl programs can be interactive).
+A B<command>-X<shell program, defined>line B<interpreter>. The program that
+interactively gives you a prompt, accepts one or more B<lines> of input,
+and executes the programs you mentioned, feeding each of them their proper
+B<arguments> and input data. Shells can also execute scripts containing
+such commands. Under Unix, typical shells include the Bourne shell
+(I</bin/sh>), the C shell (I</bin/csh>), and the Korn shell (I</bin/ksh>).
+Perl is not strictly a shell because it’s not interactive (although Perl
+programs can be interactive).
 
 =item side effects
 
-Something extra that happens when you evaluate an L</expression>.
-Nowadays it can refer to almost anything.  For example, evaluating a
-simple assignment statement typically has the "side effect" of
-assigning a value to a variable.  (And you thought assigning the value
-was your primary intent in the first place!)  Likewise, assigning a
-value to the special variable C<$|> (C<$AUTOFLUSH>) has the side
-effect of forcing a flush after every L<write|perlfunc/write> or
-L<print|perlfunc/print> on the currently selected filehandle.
+Something extra X<side effects>that happens when you evaluate an
+B<expression>. Nowadays it can refer to almost anything. For example,
+evaluating a simple assignment statement typically has the “side effect” of
+assigning a value to a variable. (And you thought assigning the value was
+your primary intent in the first place!) Likewise, assigning a value to the
+special variable C<$|> (C<$AUTOFLUSH>) has the side effect of forcing a
+flush after every C<write> or C<print> on the currently selected
+filehandle.
+
+=item sigil
+
+A glyph X<sigils, defined>used in magic. Or, for Perl, the symbol in front
+of a variable name, such as C<$>, C<@>, and C<%>.
 
 =item signal
 
-A bolt out of the blue; that is, an event triggered by the
-L</operating system>, probably when you're least expecting it.
+A bolt X<signals and signal handling, about>out of the blue; that is, an
+event triggered by the B<operating system>, probably when you’re least
+expecting it.
 
 =item signal handler
 
-A L</subroutine> that, instead of being content to be called in the
-normal fashion, sits around waiting for a bolt out of the blue before
-it will deign to L</execute>.  Under Perl, bolts out of the blue are
-called signals, and you send them with the L<kill|perlfunc/kill>
-built-in.  See L<perlvar/%SIG> and L<perlipc/Signals>.
+A B<subroutine> that, X<handlers, signal>instead of being content to be
+called in the normal fashion, sits around waiting for a bolt out of the
+blue before it will deign to B<execute>. Under Perl, bolts out of the blue
+are called signals, and you send them with the C<kill> built-in. See the
+C<%SIG> hash in Camel chapter 25, “Special Names” and the section “Signals”
+in Camel chapter 15, “Interprocess Communication”.
 
 =item single inheritance
 
-The features you got from your mother, if she told you that you don't
-have a father.  (See also L</inheritance> and L</multiple
-inheritance>.)  In computer languages, the notion that
-L<classes|/class> reproduce asexually so that a given class can only
-have one direct ancestor or L</base class>.  Perl supplies no such
-restriction, though you may certainly program Perl that way if you
-like.
+The features X<single inheritance>X<inheritance, single>you got from your
+mother, if she told you that you don’t have a father. (See also
+B<inheritance> and B<multiple inheritance>.) In computer languages, the
+idea that B<classes> reproduce asexually so that a given class can only
+have one direct ancestor or B<base class>. Perl supplies no such
+restriction, though you may certainly program Perl that way if you like.
 
 =item slice
 
-A selection of any number of L<elements|/element> from a L</list>,
-L</array>, or L</hash>.
+A selection X<slices of elements>X<elements, slices of>of any number of
+B<elements> from a B<list>, B<array>, or B<hash>.
 
 =item slurp
 
-To read an entire L</file> into a L</string> in one operation.
+To read an X<slurp (term)>entire B<file> into a B<string> in one operation.
 
 =item socket
 
-An endpoint for network communication among multiple
-L<processes|/process> that works much like a telephone or a post
-office box.  The most important thing about a socket is its L</network
-address> (like a phone number).  Different kinds of sockets have
-different kinds of addresses--some look like filenames, and some
-don't.
+An endpoint for X<sockets, defined>network communication among multiple
+B<processes> that works much like a telephone or a post office box. The
+most important thing about a socket is its B<network address> (like a phone
+number). Different kinds of sockets have different kinds of addresses—some
+look like filenames, and some don’t.
 
 =item soft reference
 
-See L</symbolic reference>.
+SeeX<soft references>X<references, soft> B<symbolic reference>.
 
 =item source filter
 
-A special kind of L</module> that does L</preprocessing> on your
-script just before it gets to the L</tokener>.
+A special X<source filters>X<filters, source>kind of B<module> that does
+B<preprocessing> on your script just before it gets to the B<tokener>.
 
 =item stack
 
-A device you can put things on the top of, and later take them back
-off in the opposite order in which you put them on.  See L</LIFO>.
+A X<stacks, defined>device you can put things on the top of, and later take
+them back off in the opposite order in which you put them on. See B<LIFO>.
 
 =item standard
 
-Included in the official Perl distribution, as in a standard module, a
-standard tool, or a standard Perl L</manpage>.
+Included X<standard (term)>in the official Perl distribution, as in a
+standard module, a standard tool, or a standard Perl B<manpage>.
 
 =item standard error
 
-The default output L</stream> for nasty remarks that don't belong in
-L</standard output>.  Represented within a Perl program by the
-L</filehandle> L</STDERR>.  You can use this stream explicitly, but the
-L<die|perlfunc/die> and L<warn|perlfunc/warn> built-ins write to your
-standard error stream automatically.
-
-=item standard I/O
-
-A standard C library for doing L<buffered|/buffer> input and output to
-the L</operating system>.  (The "standard" of standard I/O is only
-marginally related to the "standard" of standard input and output.)
-In general, Perl relies on whatever implementation of standard I/O a
-given operating system supplies, so the buffering characteristics of a
-Perl program on one machine may not exactly match those on another
-machine.  Normally this only influences efficiency, not semantics.  If
-your standard I/O package is doing block buffering and you want it to
-L</flush> the buffer more often, just set the C<$|> variable to a true
-value.
+The default output B<stream> for nasty remarks that don’t belong in
+B<standard output>. Represented within a Perl program by theX<STDERR
+filehandle, about> output>  B<filehandle> C<STDERR>. You can use this
+stream explicitly, but the C<die> and C<warn> built-ins write to your
+standard error stream automatically (unless trapped or otherwise
+intercepted).
 
 =item standard input
 
-The default input L</stream> for your program, which if possible
-shouldn't care where its data is coming from.  Represented within a
-Perl program by the L</filehandle> L</STDIN>.
+The X<STDIN filehandle, about>default input B<stream> for your program,
+which if possible shouldn’t care where its data is coming from. Represented
+within a Perl program by the B<filehandle> C<STDIN>.
+
+=item standard I/O
+
+A X<standard I/O>X<I/O (Input/Output), standard>X<Input/Output (I/O),
+standard>X<STDIO filehandle>standard C library for doing B<buffered> input
+and output to the B<operating system>. (The “standard” of standard I/O is
+at most marginally related to the “standard” of standard input and output.)
+In general, Perl relies on whatever implementation of standard I/O a given
+operating system supplies, so the buffering characteristics of a Perl
+program on one machine may not exactly match those on another machine.
+Normally this only influences efficiency, not semantics. If your standard
+I/O package is doing block buffering and you want it to B<flush> the buffer
+more often, just set the C<$|> variable to a true value.
+
+=item Standard Library
+
+Everything X<Standard Perl Library, about>that comes with the official
+I<perl> distribution. Some vendor versions of I<perl> change their
+distributions, leaving out some parts or including extras. See also
+B<dual-lived>.
 
 =item standard output
 
-The default output L</stream> for your program, which if possible
-shouldn't care where its data is going.  Represented within a Perl
-program by the L</filehandle> L</STDOUT>.
-
-=item stat structure
-
-A special internal spot in which Perl keeps the information about the
-last L</file> on which you requested information.
+The X<STDOUT filehandle, about>default output B<stream> for your program,
+which if possible shouldn’t care where its data is going. Represented
+within a Perl program by the B<filehandle> C<STDOUT>.
 
 =item statement
 
-A L</command> to the computer about what to do next, like a step in a
-recipe: "Add marmalade to batter and mix until mixed."  A statement is
-distinguished from a L</declaration>, which doesn't tell the computer
-to do anything, but just to learn something.
+A B<command> to X<statements, about>the computer about what to do next,
+like a step in a recipe: “Add marmalade to batter and mix until mixed.” A
+statement is distinguished from a B<declaration>, which doesn’t tell the
+computer to do anything, but just to learn something.
 
 =item statement modifier
 
-A L</conditional> or L</loop> that you put after the L</statement>
-instead of before, if you know what we mean.
+A B<conditional> X<statement modifiers, about>X<modifiers, statement>or
+B<loop> that you put after the B<statement> instead of before, if you know
+what we mean.
 
 =item static
 
-Varying slowly compared to something else.  (Unfortunately, everything
-is relatively stable compared to something else, except for certain
-elementary particles, and we're not so sure about them.)  In
-computers, where things are supposed to vary rapidly, "static" has a
-derogatory connotation, indicating a slightly dysfunctional
-L</variable>, L</subroutine>, or L</method>.  In Perl culture, the
-word is politely avoided.
+Varying X<static (term)>slowly compared to something else. (Unfortunately,
+everything is relatively stable compared to something else, except for
+certain elementary particles, and we’re not so sure about them.) In
+computers, where things are supposed to vary rapidly, “static” has a
+derogatory connotation, indicating a slightly dysfunctional B<variable>,
+B<subroutine>, or B<method>. In Perl culture, the word is politely avoided.
+
+If you’re a C or C++ programmer, you might be looking for Perl’s C<state>
+keyword.
 
 =item static method
 
-No such thing.  See L</class method>.
+No such X<static methods>X<methods, static>thing. See B<class method>.
 
 =item static scoping
 
-No such thing.  See L</lexical scoping>.
+No such thing. See B<lexical scoping>.
 
 =item static variable
 
-No such thing.  Just use a L</lexical variable> in a scope larger than
-your L</subroutine>.
+No such X<static variables>X<variables, static>thing. Just use a B<lexical
+variable> in a scope larger than your B<subroutine>, or declare it with
+C<state> instead of with C<my>.
+
+=item stat structure
+
+A special X<stat structure>X<data structures, stat structure>internal spot
+in which Perl keeps the information about the last B<file> on which you
+requested information.
 
 =item status
 
-The L</value> returned to the parent L</process> when one of its child
-processes dies.  This value is placed in the special variable C<$?>.
-Its upper eight L<bits|/bit> are the exit status of the defunct
-process, and its lower eight bits identify the signal (if any) that
-the process died from.  On Unix systems, this status value is the same
-as the status word returned by I<wait>(2).  See L<perlfunc/system>.
+The B<value> X<status value>X<values, status>X<exit status>returned to the
+parent B<process> when one of its child processes dies. This value is
+placed in the special variable C<$?>. Its upper eight B<bits> are the exit
+status of the defunct process, and its lower eight bits identify the signal
+(if any) that the process died from. On Unix systems, this status value is
+the same as the status word returned by I<wait>(2). See C<system> in Camel
+chapter 27, “Functions”.
 
 =item STDERR
 
-See L</standard error>.
+See B<standard error>.
 
 =item STDIN
 
-See L</standard input>.
+See B<standard input>.
 
 =item STDIO
 
-See L</standard IE<sol>O>.
+See B<standard I/O>.
 
 =item STDOUT
 
-See L</standard output>.
+See B<standard output>.
 
 =item stream
 
-A flow of data into or out of a process as a steady sequence of bytes
-or characters, without the appearance of being broken up into packets.
-This is a kind of L</interface>--the underlying L</implementation> may
-well break your data up into separate packets for delivery, but this
-is hidden from you.
+A flow X<streaming data>X<processes, streaming data>of data into or out of
+a process as a steady sequence of bytes or characters, without the
+appearance of being broken up into packets. This is a kind of
+B<interface>—the underlying B<implementation> may well break your data up
+into separate packets for delivery, but this is hidden from you.
 
 =item string
 
-A sequence of characters such as "He said !@#*&%@#*?!".  A string does
-not have to be entirely printable.
+A sequence X<strings, defined>of characters such as “He said !@#*&%@#*?!”.
+A string does not have to be entirely printable.
 
 =item string context
 
-The situation in which an expression is expected by its surroundings
-(the code calling it) to return a L</string>.  See also L</context>
-and L</numeric context>.
+The situation X<string context>X<context, string>in which an expression is
+expected by its surroundings (the code calling it) to return a B<string>.
+See also B<context> and B<numeric context>.
 
 =item stringification
 
-The process of producing a L</string> representation of an abstract
-object.
+The process X<stringification>of producing a B<string> representation of an
+abstract object.
 
 =item struct
 
-C keyword introducing a structure definition or name.
+C keyword X<struct keyword>introducing a structure definition or name.
 
 =item structure
 
-See L</data structure>.
+SeeX<structures> B<data structure>.
 
 =item subclass
 
-See L</derived class>.
+See B<derived class>.
 
 =item subpattern
 
-A component of a L</regular expression> pattern.
+A X<subpatterns, defined>component of a B<regular expression> pattern.
 
 =item subroutine
 
-A named or otherwise accessible piece of program that can be invoked
-from elsewhere in the program in order to accomplish some sub-goal of
-the program.  A subroutine is often parameterized to accomplish
-different but related things depending on its input
-L<arguments|/argument>.  If the subroutine returns a meaningful
-L</value>, it is also called a L</function>.
+A X<subroutines, defined>named or otherwise accessible piece of program
+that can be invoked from elsewhere in the program in order to accomplish
+some subgoal of the program. A subroutine is often parameterized to
+accomplish different but related things depending on its input
+B<arguments>. If the subroutine returns a meaningful B<value>, it is also
+called a B<function>.
 
 =item subscript
 
-A L</value> that indicates the position of a particular L</array>
-L</element> in an array.
+A B<value> X<subscripts>that indicates the position of a particular
+B<array> B<element> in an array.
 
 =item substitution
 
-Changing parts of a string via the C<s///> operator.  (We avoid use of
-this term to mean L</variable interpolation>.)
+Changing X<substitution (s///) operator, about>X<strings, substitution
+in>X<s/// (substitution) operator, about>parts of a string via the C<s///>
+operator. (We avoid use of this term to mean B<variable interpolation>.)
 
 =item substring
 
-A portion of a L</string>, starting at a certain L</character>
-position (L</offset>) and proceeding for a certain number of
+A portion of a B<string>, X<substrings (term)>starting at a certain
+B<character> position (B<offset>) and proceeding for a certain number of
 characters.
 
 =item superclass
 
-See L</base class>.
+See B<base class>.
 
 =item superuser
 
-The person whom the L</operating system> will let do almost anything.
-Typically your system administrator or someone pretending to be your
-system administrator.  On Unix systems, the L</root> user.  On Windows
+The X<superusers>person whom the B<operating system> will let do almost
+anything. Typically your system administrator or someone pretending to be
+your system administrator. On Unix systems, the B<root> user. On Windows
 systems, usually the Administrator user.
 
 =item SV
 
-Short for "scalar value".  But within the Perl interpreter every
-L</referent> is treated as a member of a class derived from SV, in an
-object-oriented sort of way.  Every L</value> inside Perl is passed
-around as a C language C<SV*> pointer.  The SV L</struct> knows its
-own "referent type", and the code is smart enough (we hope) not to try
-to call a L</hash> function on a L</subroutine>.
+Short X<scalar values, about>X<values, scalar>for “scalar value”. But
+within the Perl interpreter, every B<referent> is treated as a member of a
+class derived from SV, in an object-oriented sort of way. Every B<value>
+inside Perl is passed around as a C language C<SV*> pointer. The SV
+B<struct> knows its own “referent type”, and the code is smart enough (we
+hope) not to try to call a B<hash> function on a B<subroutine>.
 
 =item switch
 
-An option you give on a command line to influence the way your program
-works, usually introduced with a minus sign.  The word is also used as
-a nickname for a L</switch statement>.
+An X<switches, about>X<switches>option you give on a command line to
+influence the way your program works, usually introduced with a minus sign.
+The word is also used as a nickname for a B<switch statement>.
 
 =item switch cluster
 
-The combination of multiple command-line switches (e.g., B<-a -b -c>)
-into one switch (e.g., B<-abc>).  Any switch with an additional
-L</argument> must be the last switch in a cluster.
+The X<switch clusters>X<clusters, switch>combination of multiple command-
+line switches (I<e.g.>, C<–a –b –c>) into one switch (I<e.g.>, C<–abc>).
+Any switch with an additional B<argument> must be the last switch in a
+cluster.
 
 =item switch statement
 
-A program technique that lets you evaluate an L</expression> and then,
-based on the value of the expression, do a multiway branch to the
-appropriate piece of code for that value.  Also called a "case
-structure", named after the similar Pascal construct.  See
-See L<perlsyn/Basic BLOCKs>.
+A X<switch statement>X<statements, switch>program technique that lets you
+evaluate an B<expression> and then, based on the value of the expression,
+do a multiway branch to the appropriate piece of code for that value. Also
+called a “case structure”, named after the similar Pascal construct. Most
+switch statements in Perl are spelled C<given>. See “The C<given>
+statement” in Camel chapter 4, “Statements and Declarations”.
 
 =item symbol
 
-Generally, any L</token> or L</metasymbol>.  Often used more
-specifically to mean the sort of name you might find in a L</symbol
+Generally, X<symbols>X<symbols>any B<token> or B<metasymbol>. Often used
+more specifically to mean the sort of name you might find in a B<symbol
 table>.
-
-=item symbol table
-
-Where a L</compiler> remembers symbols.  A program like Perl must
-somehow remember all the names of all the L<variables|/variable>,
-L<filehandles|/filehandle>, and L<subroutines|/subroutine> you've
-used.  It does this by placing the names in a symbol table, which is
-implemented in Perl using a L</hash table>.  There is a separate
-symbol table for each L</package> to give each package its own
-L</namespace>.
 
 =item symbolic debugger
 
-A program that lets you step through the L<execution|/execute> of your
-program, stopping or printing things out here and there to see whether
-anything has gone wrong, and if so, what.  The "symbolic" part just
-means that you can talk to the debugger using the same symbols with
-which your program is written.
+A program X<symbolic debugger>X<debugger, about>that lets you step through
+the B<execution> of your program, stopping or printing things out here and
+there to see whether anything has gone wrong, and, if so, what. The
+“symbolic” part just means that you can talk to the debugger using the same
+symbols with which your program is written.
 
 =item symbolic link
 
-An alternate filename that points to the real L</filename>, which in
-turn points to the real L</file>.  Whenever the L</operating system>
-is trying to parse a L</pathname> containing a symbolic link, it
-merely substitutes the new name and continues parsing.
+An alternate X<symbolic links>X<links, symbolic>filename that points to the
+real B<filename>, which in turn points to the real B<file>. Whenever the
+B<operating system> is trying to parse a B<pathname> containing a symbolic
+link, it merely substitutes the new name and continues parsing.
 
 =item symbolic reference
 
-A variable whose value is the name of another variable or subroutine.
-By L<dereferencing|/dereference> the first variable, you can get at
-the second one.  Symbolic references are illegal under L<use strict
-'refs'|strict/strict refs>.
+A variable X<symbolic references>X<references, symbolic>whose value is the
+name of another variable or subroutine. By B<dereferencing> the first
+variable, you can get at the second one. Symbolic references are illegal
+under C<use strict "refs">.
+
+=item symbol table
+
+Where X<symbol tables, about>a B<compiler> remembers symbols. A program
+like Perl must somehow remember all the names of all the B<variables>,
+B<filehandles>, and B<subroutines> you’ve used. It does this by placing the
+names in a symbol table, which is implemented in Perl using a B<hash
+table>. There is a separate symbol table for each B<package> to give each
+package its own B<namespace>.
 
 =item synchronous
 
-Programming in which the orderly sequence of events can be determined;
-that is, when things happen one after the other, not at the same time.
+Programming X<synchronous (term)>in which the orderly sequence of events
+can be determined; that is, when things happen one after the other, not at
+the same time.
 
 =item syntactic sugar
 
-An alternative way of writing something more easily; a shortcut.
+An X<syntactic sugar>alternative way of writing something more easily; a
+shortcut.
 
 =item syntax
 
-From Greek, "with-arrangement".  How things (particularly symbols) are
-put together with each other.
+From X<syntax, about>Greek σύνταξις, “with-arrangement”. How things
+(particularly symbols) are put together with each other.
 
 =item syntax tree
 
-An internal representation of your program wherein lower-level
-L<constructs|/construct> dangle off the higher-level constructs
-enclosing them.
+An internal X<syntax tree>representation of your program wherein
+lower-level B<constructs> dangle off the higher-level constructs enclosing
+them.
 
 =item syscall
 
-A L</function> call directly to the L</operating system>.  Many of the
-important subroutines and functions you use aren't direct system
-calls, but are built up in one or more layers above the system call
-level.  In general, Perl programmers don't need to worry about the
-distinction.  However, if you do happen to know which Perl functions
-are really syscalls, you can predict which of these will set the C<$!>
-(C<$ERRNO>) variable on failure.  Unfortunately, beginning programmers
-often confusingly employ the term "system call" to mean what happens
-when you call the Perl L<system|perlfunc/system> function, which
-actually involves many syscalls.  To avoid any confusion, we nearly
-always use say "syscall" for something you could call indirectly via
-Perl's L<syscall|perlfunc/syscall> function, and never for something
-you would call with Perl's L<system|perlfunc/system> function.
+A B<function> X<syscall function, about>call directly to the B<operating
+system>. Many of the important subroutines and functions you use aren’t
+direct system calls, but are built up in one or more layers above the
+system call level. In general, Perl programmers don’t need to worry about
+the distinction. However, if you do happen to know which Perl functions are
+really syscalls, you can predict which of these will set the C<$!>
+(C<$ERRNO>) variable on failure. Unfortunately, beginning programmers often
+confusingly employ the term “system call” to mean what happens when you
+call the Perl C<system> function, which actually involves many syscalls. To
+avoid any confusion, we nearly always say “syscall” for something you could
+call indirectly via Perl’s C<syscall> function, and never for something you
+would call with Perl’s C<system> function.
 
-=back
+=item taint checks
 
-=head2 T
-
-=over 4
+The X<taint checks, about>special bookkeeping Perl does to track the flow
+of external data through your program and disallow their use in system
+commands.
 
 =item tainted
 
-Said of data derived from the grubby hands of a user and thus unsafe
-for a secure program to rely on.  Perl does taint checks if you run a
-L</setuid> (or L</setgid>) program, or if you use the B<-T> switch.
+Said of X<tainted data, about>data derived from the grubby hands of a user,
+and thus unsafe for a secure program to rely on. Perl does taint checks if
+you run a B<setuid> (or B<setgid>) program, or if you use the C<–T> switch.
+
+=item taint mode
+
+Running X<taint mode>under the C<–T> switch, marking all external data as
+suspect and refusing to use it with system commands. See Camel chapter 20,
+“Security”.
 
 =item TCP
 
-Short for Transmission Control Protocol.  A protocol wrapped around
-the Internet Protocol to make an unreliable packet transmission
-mechanism appear to the application program to be a reliable
-L</stream> of bytes.  (Usually.)
+Short for X<TCP (Transmission Control Protocol)>X<Transmission Control
+Protocol (TCP)>Transmission Control Protocol. A protocol wrapped around the
+Internet Protocol to make an unreliable packet transmission mechanism
+appear to the application program to be a reliable B<stream> of bytes.
+(Usually.)
 
 =item term
 
-Short for a "terminal", that is, a leaf node of a L</syntax tree>.  A
-thing that functions grammatically as an L</operand> for the operators
-in an expression.
+Short for X<terms, defined>a “terminal”—that is, a leaf node of a B<syntax
+tree>. A thing that functions grammatically as an B<operand> for the
+operators in an expression.
 
 =item terminator
 
-A L</character> or L</string> that marks the end of another string.
-The C<$/> variable contains the string that terminates a
-L<readline|perlfunc/readline> operation, which L<chomp|perlfunc/chomp>
-deletes from the end.  Not to be confused with
-L<delimiters|/delimiter> or L<separators|/separator>.  The period at
-the end of this sentence is a terminator.
+A B<character> X<terminators (term)>X<characters, terminators>X<strings,
+terminators in>or B<string> that marks the end of another string. The C<$/>
+variable contains the string that terminates a C<readline> operation, which
+C<chomp> deletes from the end. Not to be confused with B<delimiters> or
+B<separators>. The period at the end of this sentence is a terminator.
 
 =item ternary
 
-An L</operator> taking three L<operands|/operand>.  Sometimes
-pronounced L</trinary>.
+An B<operator> X<ternary operators>taking three B<operands>. Sometimes
+pronounced B<trinary>.
 
 =item text
 
-A L</string> or L</file> containing primarily printable characters.
+A B<string> or B<file> X<text, defined>X<strings, text>X<files,
+text>X<text>containing primarily printable characters.
 
 =item thread
 
-Like a forked process, but without L</fork>'s inherent memory
-protection.  A thread is lighter weight than a full process, in that a
-process could have multiple threads running around in it, all fighting
-over the same process's memory space unless steps are taken to protect
-threads from each other.  See L<threads>.
+Like a X<threads (term)>forked process, but without B<fork>’s inherent
+memory protection. A thread is lighter weight than a full process, in that
+a process could have multiple threads running around in it, all fighting
+over the same process’s memory space unless steps are taken to protect
+threads from one another.
 
 =item tie
 
-The bond between a magical variable and its implementation class.  See
-L<perlfunc/tie> and L<perltie>.
+The bond X<tied variables, about>between a magical variable and its
+implementation class. See the C<tie> function in Camel chapter 27,
+“Functions” and Camel chapter 14, “Tied Variables”.
+
+=item titlecase
+
+The case X<titlecase characters>X<characters, titlecase>used for capitals
+that are followed by lowercase characters instead of by more capitals.
+Sometimes called sentence case or headline case. English doesn’t use
+Unicode titlecase, but casing rules for English titles are more complicated
+than simply capitalizing each word’s first character.
 
 =item TMTOWTDI
 
-There's More Than One Way To Do It, the Perl Motto.  The notion that
-there can be more than one valid path to solving a programming problem
-in context.  (This doesn't mean that more ways are always better or
-that all possible paths are equally desirable--just that there need
-not be One True Way.)  Pronounced TimToady.
+There’s More Than One Way To Do It, the Perl MottoX<TMTOWTDI acronym>. The
+notion that there can be more than one valid path to solving a programming
+problem in context. (This doesn’t mean that more ways are always better or
+that all possible paths are equally desirable—just that there need not be
+One True Way.)
 
 =item token
 
-A morpheme in a programming language, the smallest unit of text with
-semantic significance.
+A morpheme X<tokens, defined>in a programming language, the smallest unit
+of text with semantic significance.
 
 =item tokener
 
-A module that breaks a program text into a sequence of
-L<tokens|/token> for later analysis by a parser.
+A module that X<tokeners, defined>breaks a program text into a sequence of
+B<tokens> for later analysis by a parser.
 
 =item tokenizing
 
-Splitting up a program text into L<tokens|/token>.  Also known as
-"lexing", in which case you get "lexemes" instead of tokens.
+Splitting up a X<tokenizing>program text into B<tokens>. Also known as
+“lexing”, in which case you get “lexemes” instead of tokens.
 
 =item toolbox approach
 
-The notion that, with a complete set of simple tools that work well
-together, you can build almost anything you want.  Which is fine if
-you're assembling a tricycle, but if you're building a defranishizing
-comboflux regurgalator, you really want your own machine shop in which
-to build special tools.  Perl is sort of a machine shop.
+The notion that, X<toolbox approach>with a complete set of simple tools
+that work well together, you can build almost anything you want. Which is
+fine if you’re assembling a tricycle, but if you’re building a
+defranishizing comboflux regurgalator, you really want your own machine
+shop in which to build special tools. Perl is sort of a machine shop.
+
+=item topic
+
+The thing you’re X<topics (term)>working on. Structures like
+C<while(E<lt>E<gt>)>, C<for>, C<foreach>, and C<given> set the topic for
+you by assigning to C<$_>, the default (I<topic>) variable.
 
 =item transliterate
 
-To turn one string representation into another by mapping each
-character of the source string to its corresponding character in the
-result string.  See
-L<perlop/trE<sol>SEARCHLISTE<sol>REPLACEMENTLISTE<sol>cdsr>.
+To turn one X<tr/// (transliteration) operator, about>X<strings,
+transliteration of>X<transliteration (tr///) operator, about>string
+representation into another by mapping each character of the source string
+to its corresponding character in the result string. Not to be confused
+with translation: for example, Greek I<πολύχρωμος> transliterates into
+I<polychromos> but translates into I<many-colored>. See the C<tr///>
+operator in Camel chapter 5, “Pattern Matching”.
 
 =item trigger
 
-An event that causes a L</handler> to be run.
+An event X<triggers (term)>that causes a B<handler> to be run.
 
 =item trinary
 
-Not a stellar system with three stars, but an L</operator> taking
-three L<operands|/operand>.  Sometimes pronounced L</ternary>.
+Not a X<trinary operators>stellar system with three stars, but an
+B<operator> taking three B<operands>. Sometimes pronounced B<ternary>.
 
 =item troff
 
-A venerable typesetting language from which Perl derives the name of
-its C<$%> variable and which is secretly used in the production of
-Camel books.
+A venerable X<troff language>typesetting language from which Perl derives
+the name of its C<$%> variable and which is secretly used in the production
+of Camel books.
 
 =item true
 
-Any scalar value that doesn't evaluate to 0 or C<"">.
+Any X<true values>X<values, true>scalar value that doesn’t evaluate to 0 or
+C<"">.
 
 =item truncating
 
-Emptying a file of existing contents, either automatically when
-opening a file for writing or explicitly via the
-L<truncate|perlfunc/truncate> function.
+Emptying a X<truncate function>X<files, truncating>file of existing
+contents, either automatically when opening a file for writing or
+explicitly via the C<truncate> function.
 
 =item type
 
-See L</data type> and L</class>.
+SeeX<type> B<data type> and B<class>.
 
 =item type casting
 
-Converting data from one type to another.  C permits this.  Perl does
-not need it.  Nor want it.
-
-=item typed lexical
-
-A L</lexical variable> that is declared with a L</class> type: C<my
-Pony $bill>.
+Converting X<type casting>data from one type to another. C permits this.
+Perl does not need it. Nor want it.
 
 =item typedef
 
-A type definition in the C language.
+A type X<typedef>definition in the C and C++ languages.
+
+=item typed lexical
+
+A B<lexical variable> X<typed lexicals>X<lexical variables, typed
+lexicals>X<variables, variable> lexical>that is declared with a B<class>
+type: C<my Pony $bill>.
 
 =item typeglob
 
-Use of a single identifier, prefixed with C<*>.  For example, C<*name>
-stands for any or all of C<$name>, C<@name>, C<%name>, C<&name>, or
-just C<name>.  How you use it determines whether it is interpreted as
-all or only one of them.  See L<perldata/Typeglobs and Filehandles>.
+Use of X<typeglobs, defined>a single identifier, prefixed with C<*>. For
+example, C<*name> stands for any or all of C<$name>, C<@name>, C<%name>,
+C<&name>, or just C<name>. How you use it determines whether it is
+interpreted as all or only one of them. See “Typeglobs and Filehandles” in
+Camel chapter 2, “Bits and Pieces”.
 
 =item typemap
 
-A description of how C types may be transformed to and from Perl types
-within an L</extension> module written in L</XS>.
-
-=back
-
-=head2 U
-
-=over 4
+A description of X<typemap>how C types may be transformed to and from Perl
+types within an B<extension> module written in B<XS>.
 
 =item UDP
 
-User Datagram Protocol, the typical way to send L<datagrams|/datagram>
-over the Internet.
+User Datagram Protocol, the X<User Datagram Protocol (UDP)>X<UDP (User
+Datagram Protocol)>X<datagrams, UDP support>typical way to send
+B<datagrams> over the Internet.
 
 =item UID
 
-A user ID.  Often used in the context of L</file> or L</process>
-ownership.
+A user ID. X<UID (user ID)>X<user ID (UID)>Often used in the context of
+B<file> or B<process> ownership.
 
 =item umask
 
-A mask of those L</permission bits> that should be forced off when
-creating files or directories, in order to establish a policy of whom
-you'll ordinarily deny access to.  See the L<umask|perlfunc/umask>
-function.
+A X<umask function>mask of those B<permission bits> that should be forced
+off when creating files or directories, in order to establish a policy of
+whom you’ll ordinarily deny access to. See the C<umask> function.
 
 =item unary operator
 
-An operator with only one L</operand>, like C<!> or
-L<chdir|perlfunc/chdir>.  Unary operators are usually prefix
-operators; that is, they precede their operand.  The C<++> and C<-->
-operators can be either prefix or postfix.  (Their position I<does>
-change their meanings.)
+An X<unary operators, about>operator with only one B<operand>, like C<!> or
+C<chdir>. Unary operators are usually prefix operators; that is, they
+precede their operand. The C<++> and C<––> operators can be either prefix
+or postfix. (Their position I<does> change their meanings.)
 
 =item Unicode
 
-A character set comprising all the major character sets of the world,
-more or less.  See L<perlunicode> and L<http://www.unicode.org>.
+A character set X<Unicode, about>comprising all the major character sets of
+the world, more or less. See L<http://www.unicode.org>.
 
 =item Unix
 
-A very large and constantly evolving language with several alternative
-and largely incompatible syntaxes, in which anyone can define anything
-any way they choose, and usually do.  Speakers of this language think
-it's easy to learn because it's so easily twisted to one's own ends,
+A very large X<Unix language>and constantly evolving language with several
+alternative and largely incompatible syntaxes, in which anyone can define
+anything any way they choose, and usually do. Speakers of this language
+think it’s easy to learn because it’s so easily twisted to one’s own ends,
 but dialectical differences make tribal intercommunication nearly
-impossible, and travelers are often reduced to a pidgin-like subset of
-the language.  To be universally understood, a Unix shell programmer
-must spend years of study in the art.  Many have abandoned this
-discipline and now communicate via an Esperanto-like language called
-Perl.
+impossible, and travelers are often reduced to a pidgin-like subset of the
+language. To be universally understood, a Unix shell programmer must spend
+years of study in the art. Many have abandoned this discipline and now
+communicate via an Esperanto-like language called Perl.
 
-In ancient times, Unix was also used to refer to some code that a
-couple of people at Bell Labs wrote to make use of a PDP-7 computer
-that wasn't doing much of anything else at the time.
+In ancient times, Unix was also used to refer to some code that a couple of
+people at Bell Labs wrote to make use of a PDP-7 computer that wasn’t doing
+much of anything else at the time.
 
-=back
+=item uppercase
 
-=head2 V
-
-=over 4
+In Unicode, X<uppercase characters>X<characters, uppercase>not just
+characters with the General Category of Uppercase Letter, but any character
+with the Uppercase property, including some Letter Numbers and Symbols. Not
+to be confused with B<titlecase>.
 
 =item value
 
-An actual piece of data, in contrast to all the variables, references,
-keys, indexes, operators, and whatnot that you need to access the
-value.
+An actual piece X<values, defined>of data, in contrast to all the
+variables, references, keys, indices, operators, and whatnot that you need
+to access the value.
 
 =item variable
 
-A named storage location that can hold any of various kinds of
-L</value>, as your program sees fit.
+A named storage X<variables, defined>X<variables>location that can hold any
+of various kinds of B<value>, as your program sees fit.
 
 =item variable interpolation
 
-The L</interpolation> of a scalar or array variable into a string.
+TheX<variable interpolation>X<interpolation, variable> B<interpolation> of
+a scalar or array variable into a string.
 
 =item variadic
 
-Said of a L</function> that happily receives an indeterminate number
-of L</actual arguments>.
+Said of X<variadic (term)>a B<function> that happily receives an
+indeterminate number of B<actual arguments>.
 
 =item vector
 
-Mathematical jargon for a list of L<scalar values|/scalar value>.
+Mathematical X<vectors>jargon for a list of B<scalar values>.
 
 =item virtual
 
-Providing the appearance of something without the reality, as in:
-virtual memory is not real memory.  (See also L</memory>.)  The
-opposite of "virtual" is "transparent", which means providing the
-reality of something without the appearance, as in: Perl handles the
-variable-length UTF-8 character encoding transparently.
+Providing the X<virtual (term)>appearance of something without the reality,
+as in: virtual memory is not real memory. (See also B<memory>.) The
+opposite of “virtual” is “transparent”, which means providing the reality
+of something without the appearance, as in: Perl handles the
+variable-length UTF‑8 character encoding transparently.
 
 =item void context
 
-A form of L</scalar context> in which an L</expression> is not
-expected to return any L</value> at all and is evaluated for its
-L</side effects> alone.
+A form X<void context>X<context, void>of B<scalar context> in which an
+B<expression> is not expected to return any B<value> at all and is
+evaluated for its B<side effects> alone.
 
 =item v-string
 
-A "version" or "vector" L</string> specified with a C<v> followed by a
-series of decimal integers in dot notation, for instance,
-C<v1.20.300.4000>.  Each number turns into a L</character> with the
-specified ordinal value.  (The C<v> is optional when there are at
-least three integers.)
-
-=back
-
-=head2 W
-
-=over 4
+A “version” or “vector”X<v–strings>X<strings, v–strings> B<string>
+specified with a C<v> followed by a series of decimal integers in dot
+notation, for instance, C<v1.20.300.4000>. Each number turns into a
+B<character> with the specified ordinal value. (The C<v> is optional when
+there are at least three integers.)
 
 =item warning
 
-A message printed to the L</STDERR> stream to the effect that something
-might be wrong but isn't worth blowing up over.  See L<perlfunc/warn>
-and the L<warnings> pragma.
+A message X<warning messages>X<STDERR filehandle, warning messages
+and>printed to the C<STDERR> stream to the effect that something might be
+wrong but isn’t worth blowing up over. See C<warn> in Camel chapter 27,
+“Functions” and the C<warnings> pragma in Camel chapter 28, “Pragmantic
+Modules”.
 
 =item watch expression
 
-An expression which, when its value changes, causes a breakpoint in
-the Perl debugger.
+An expression which, X<watch expression>X<expressions, watch>when its value
+changes, causes a breakpoint in the Perl debugger.
+
+=item weak reference
+
+A X<weak references>X<references, weak>reference that doesn’t get counted
+normally. When all the normal references to data disappear, the data
+disappears. These are useful for circular references that would never
+disappear otherwise.
 
 =item whitespace
 
-A L</character> that moves your cursor but doesn't otherwise put
-anything on your screen.  Typically refers to any of: space, tab, line
-feed, carriage return, or form feed.
+A B<character> X<whitespace characters>X<characters, whitespace>that moves
+your cursor but doesn’t otherwise put anything on your screen. Typically
+refers to any of: space, tab, line feed, carriage return, or form feed. In
+Unicode, matches many other characters that Unicode considers whitespace,
+including the ɴ-ʙʀ .
 
 =item word
 
-In normal "computerese", the piece of data of the size most
-efficiently handled by your computer, typically 32 bits or so, give or
-take a few powers of 2.  In Perl culture, it more often refers to an
-alphanumeric L</identifier> (including underscores), or to a string of
-nonwhitespace L<characters|/character> bounded by whitespace or string
-boundaries.
+In normal “computerese”, the X<words (term)>piece of data of the size most
+efficiently handled by your computer, typically 32 bits or so, give or take a
+few powers of 2. In Perl culture, it more often refers to an alphanumeric
+B<identifier> (including underscores), or to a string of nonwhitespace
+B<characters> bounded by whitespace or string boundaries.
 
 =item working directory
 
-Your current L</directory>, from which relative pathnames are
-interpreted by the L</operating system>.  The operating system knows
-your current directory because you told it with a
-L<chdir|perlfunc/chdir> or because you started out in the place where
-your parent L</process> was when you were born.
+Your X<working directory>X<directories, working>current B<directory>, from
+which relative pathnames are interpreted by the B<operating system>. The
+operating system knows your current directory because you told it with a
+C<chdir>, or because you started out in the place where your parent
+B<process> was when you were born.
 
 =item wrapper
 
-A program or subroutine that runs some other program or subroutine for
-you, modifying some of its input or output to better suit your
-purposes.
+A program X<wrappers (term)>or subroutine that runs some other program or
+subroutine for you, modifying some of its input or output to better suit
+your purposes.
 
 =item WYSIWYG
 
-What You See Is What You Get.  Usually used when something that
-appears on the screen matches how it will eventually look, like Perl's
-L<format|perlfunc/format> declarations.  Also used to mean the
-opposite of magic because everything works exactly as it appears, as
-in the three-argument form of L<open|perlfunc/open>.
-
-=back
-
-=head2 X
-
-=over 4
+What X<WYSIWYG acronym>You See Is What You Get. Usually used when something
+that appears on the screen matches how it will eventually look, like Perl’s
+C<format> declarations. Also used to mean the opposite of magic because
+everything works exactly as it appears, as in the three- argument form of
+C<open>.
 
 =item XS
 
-A language to extend Perl with L<C> and C++. XS is an interface description
-file format used to create an extension interface between
-Perl and C code (or a C library) which one wishes to use with Perl.
-See L<perlxs> for the exact explanation or read the L<perlxstut>
-tutorial.
+An X<XS (eXternal Subroutine)>X<eXternal Subroutine (XS)>extraordinarily
+exported, expeditiously excellent, expressly eXternal Subroutine, executed
+in existing C or C++ or in an exciting extension language called
+(exasperatingly) XS.
 
 =item XSUB
 
-An external L</subroutine> defined in L</XS>.
-
-=back
-
-=head2 Y
-
-=over 4
+An X<XSUB (term)>external B<subroutine> defined in B<XS>.
 
 =item yacc
 
-Yet Another Compiler Compiler.  A parser generator without which Perl
-probably would not have existed.  See the file I<perly.y> in the Perl
-source distribution.
-
-=back
-
-=head2 Z
-
-=over 4
+Yet X<yacc acronym>Another Compiler Compiler. A parser generator without
+which Perl probably would not have existed. See the file I<perly.y> in the
+Perl source distribution.
 
 =item zero width
 
-A subpattern L</assertion> matching the L</null string> between
-L<characters|/character>.
+A X<zero–width assertions>X<subpatterns, zero–width assertions>X<assertions
+(in regexes), zero–width>subpattern B<assertion> matching the B<null
+string> between B<characters>.
 
 =item zombie
 
-A process that has died (exited) but whose parent has not yet received
-proper notification of its demise by virtue of having called
-L<wait|perlfunc/wait> or L<waitpid|perlfunc/waitpid>.  If you
-L<fork|perlfunc/fork>, you must clean up after your child processes
-when they exit, or else the process table will fill up and your system
-administrator will Not Be Happy with you.
+A process X<zombie processes>X<processes, zombie>that has died (exited) but
+whose parent has not yet received proper notification of its demise by
+virtue of having called C<wait> or C<waitpid>. If you C<fork>, you must
+clean up after your child processes when they exit; otherwise, the process
+table will fill up and your system administrator will Not Be Happy with
+you.
 
 =back
 
 =head1 AUTHOR AND COPYRIGHT
 
-Based on the Glossary of Programming Perl, Third Edition,
-by Larry Wall, Tom Christiansen & Jon Orwant.
-Copyright (c) 2000, 1996, 1991 O'Reilly Media, Inc.
+Based on the Glossary of I<Programming Perl>, Fourth Edition,
+by Tom Christiansen, brian d foy, Larry Wall, & Jon Orwant.
+Copyright (c) 2000, 1996, 1991, 2012 O'Reilly Media, Inc.
 This document may be distributed under the same terms as Perl itself.


### PR DESCRIPTION
This is a totally un-looked-at-by-me patch providing the glossary used in the new edition of the Camel.  It is much more extensive than the current one.
