### PR TITLE
improved a file slurp example in perlfaq5

### DIFF
--- a/lib/perlfaq5.pod
+++ b/lib/perlfaq5.pod
@@ -194,11 +194,11 @@ you can fit the whole thing in memory!):
     open my $in,  '<',  $file      or die "Can't read old file: $!"
     open my $out, '>', "$file.new" or die "Can't write new file: $!";
 
-    my @lines = do { local $/; <$in> }; # slurp!
+    my $content = do { local $/; <$in> }; # slurp!
 
         # do your magic here
 
-    print $out @lines;
+    print $out $content;
 
 Modules such as L<File::Slurp> and L<Tie::File> can help with that
 too. If you can, however, avoid reading the entire file at once. Perl


### PR DESCRIPTION
In a code example in perlfaq5, the slurped content of a file was assigned to an array @lines. This is misleading in that in slurp mode, at most one value is returned by the diamond operator, even in list context. I suggest to replace the @lines array by a $content scalar.
