### PR TITLE
perlglossary: hexadecimal: largest digit is 15 not 16

### DIFF
--- a/lib/perlglossary.pod
+++ b/lib/perlglossary.pod
@@ -1495,7 +1495,7 @@ it’s just a fancy form of quoting.
 =item hexadecimal
 
 A X<hexadecimals>number in base 16, “hex” for short. The digits for 10
-through 16 are customarily represented by the letters C<a> through C<f>.
+through 15 are customarily represented by the letters C<a> through C<f>.
 Hexadecimal constants in Perl start with C<0x>. See also the C<hex>
 function in Camel chapter 27, “Functions”.
 


### PR DESCRIPTION
Typo, please fix.
