### PR TITLE
perlfaq3: updated some links

### DIFF
--- a/lib/perlfaq3.pod
+++ b/lib/perlfaq3.pod
@@ -493,12 +493,6 @@ L<http://dickey.his.com/vile/vile.html>
 
 The following are Win32 multilanguage editor/IDEs that support Perl:
 
-=over 4
-
-=item Codewright
-
-L<http://www.borland.com/codewright/>
-
 =item MultiEdit
 
 L<http://www.MultiEdit.com/>
@@ -525,57 +519,26 @@ powerful shell environment for Win32. Your options include
 
 =over 4
 
-=item Bash
+=item bash
 
-from the Cygwin package ( L<http://sources.redhat.com/cygwin/> )
+from the Cygwin package ( L<http://cygwin.com/> )
 
-=item Ksh
-
-from the MKS Toolkit ( L<http://www.mkssoftware.com/> ), or the Bourne shell of
-the U/WIN environment ( L<http://www.research.att.com/sw/tools/uwin/> )
-
-=item Tcsh
-
-L<ftp://ftp.astron.com/pub/tcsh/> , see also
-L<http://www.primate.wisc.edu/software/csh-tcsh-book/>
-
-=item Zsh
+=item zsh
 
 L<http://www.zsh.org/>
 
 =back
 
-MKS and U/WIN are commercial (U/WIN is free for educational and
-research purposes), Cygwin is covered by the GNU General Public
-License (but that shouldn't matter for Perl use). The Cygwin, MKS,
-and U/WIN all contain (in addition to the shells) a comprehensive set
+Cygwin is covered by the GNU General Public
+License (but that shouldn't matter for Perl use). Cygwin
+contains (in addition to the shell) a comprehensive set
 of standard Unix toolkit utilities.
-
-If you're transferring text files between Unix and Windows using FTP
-be sure to transfer them in ASCII mode so the ends of lines are
-appropriately converted.
-
-On Mac OS the MacPerl Application comes with a simple 32k text editor
-that behaves like a rudimentary IDE. In contrast to the MacPerl Application
-the MPW Perl tool can make use of the MPW Shell itself as an editor (with
-no 32k limit).
 
 =over 4
 
-=item Affrus
-
-is a full Perl development environment with full debugger support
-( L<http://www.latenightsw.com> ).
-
-=item Alpha
-
-is an editor, written and extensible in Tcl, that nonetheless has
-built-in support for several popular markup and programming languages,
-including Perl and HTML ( L<http://www.his.com/~jguyer/Alpha/Alpha8.html> ).
-
 =item BBEdit and TextWrangler
 
-are text editors for Mac OS that have a Perl sensitivity mode
+are text editors for OS X that have a Perl sensitivity mode
 ( L<http://www.barebones.com/> ).
 
 =back


### PR DESCRIPTION
- Codewright is end-of-lifed by Borland.
  According to the wikipedia page it has been aquired by Embarcadero
  Software, but if I search their web page there are 0 hits on
  the name CodeWright and also no relevant hits when searching for
  'perl'.
- tcsh hardly seems relevant anymore and the link to the 'book' is
  broken. I can't find any similar 'book' on the web.
- MKS and U/WIN are not available anymore for Win32.
- Updated cygwin web link.
- Remark on transferring files via FTP seems out of place here.
- MacPerl is not a product anymore so its editor no longer a viable
  IDE.
- Affrus is no longer to be found on the product website.
- The Alpha editor had its last release more than 12 years ago.
