### PR TITLE
Use [Test::EOL] instead of [EOLTests] in dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -39,7 +39,7 @@ entered_core = 5.015000
 [Test::Compile]
 [PodSyntaxTests]
 [Test::NoTabs]
-[EOLTests]
+[Test::EOL]
 ;[Test::PodSpelling]     ; TODO: but create in the dist, with a huge stopword list
 [Test::ChangesHasContent]
 [MojibakeTests]


### PR DESCRIPTION
[EOLTests] is deprecated and will stop working in the future, see
https://metacpan.org/changes/distribution/Dist-Zilla-Plugin-Test-EOL