### PR TITLE
Fix Time::Seconds example

### DIFF
--- a/lib/perlfaq4.pod
+++ b/lib/perlfaq4.pod
@@ -486,7 +486,7 @@ operators so you can compare them directly:
 You can also get differences with a subtraction, which returns a
 L<Time::Seconds> object:
 
-    my $diff = $date1 - $date2;
+    my $date_diff = $date1 - $date2;
     print "The difference is ", $date_diff->days, " days\n";
 
 If you want to work with formatted dates, the L<Date::Manip>,


### PR DESCRIPTION
$diff in the Time::Seconds example should apparently read $date_diff

Reported by Dan Jacobson <jidanni@jidanni.org>.

Bug-Debian: https://bugs.debian.org/762816