### PR TITLE
Fixed typo of $clear_string => $clear_screen 

### DIFF
--- a/lib/perlfaq8.pod
+++ b/lib/perlfaq8.pod
@@ -200,7 +200,7 @@ method returns the string for the given capability:
     use Term::Cap;
 
     my $terminal = Term::Cap->Tgetent( { OSPEED => 9600 } );
-    my $clear_string = $terminal->Tputs('cl');
+    my $clear_screen = $terminal->Tputs('cl');
 
     print $clear_screen;
 


### PR DESCRIPTION
Fixed typo of $clear_string => $clear_screen under the "How do I clear the screen?" section