### PR TITLE
Remove link to par.perl.org, use Metacpan for docs

### DIFF
--- a/lib/perlfaq3.pod
+++ b/lib/perlfaq3.pod
@@ -936,9 +936,8 @@ You probably won't see much of a speed increase either, since most
 solutions simply bundle a Perl interpreter in the final product
 (but see L<How can I make my Perl program run faster?>).
 
-The Perl Archive Toolkit ( L<http://par.perl.org/> ) is Perl's
-analog to Java's JAR. It's freely available and on CPAN (
-L<http://search.cpan.org/dist/PAR/> ).
+The Perl Archive Toolkit is Perl's analog to Java's JAR. It's freely
+available and on CPAN ( L<https://metacpan.org/pod/PAR> ).
 
 There are also some commercial products that may work for you, although
 you have to buy a license for them.


### PR DESCRIPTION
par.perl.org redirects to perl6.org now, not the PAR distribution. I also updated the link to the PAR docs to point at metacpan instead of CPAN.