### PR TITLE
Remove reference to p5p-faq

### DIFF
--- a/lib/perlfaq1.pod
+++ b/lib/perlfaq1.pod
@@ -38,7 +38,6 @@ are a group of highly altruistic individuals committed to
 producing better software for free than you could hope to purchase for
 money. You may snoop on pending developments via the
 L<archives|http://www.nntp.perl.org/group/perl.perl5.porters/>
-or read the L<faq|http://dev.perl.org/perl5/docs/p5p-faq.html>,
 or you can subscribe to the mailing list by sending
 perl5-porters-subscribe@perl.org a subscription request
 (an empty message with no subject is fine).


### PR DESCRIPTION
The link to p5p-faq was removed from the perlhack pod years ago because the link didn't work and there appears to be no replacement.  See: https://rt.perl.org/Public/Bug/Display.html?id=116120  This updates perlfaq1 to remove this link as well.