### PR TITLE
Changing the rounding sample code in perlfaq4.pod

### DIFF
--- a/lib/perlfaq4.pod
+++ b/lib/perlfaq4.pod
@@ -124,10 +124,9 @@ need yourself.
 To see why, notice how you'll still have an issue on half-way-point
 alternation:
 
-    for (my $i = 0; $i < 1.01; $i += 0.05) { printf "%.1f ",$i}
+    for (my $i = -5; $i <= 5; $i += 0.5) { printf "%.0f ",$i }
 
-    0.0 0.1 0.1 0.2 0.2 0.2 0.3 0.3 0.4 0.4 0.5 0.5 0.6 0.7 0.7
-    0.8 0.8 0.9 0.9 1.0 1.0
+    -5 -4 -4 -4 -3 -2 -2 -2 -1 -0 0 0 1 2 2 2 3 4 4 4 5
 
 Don't blame Perl. It's the same as in C. IEEE says we have to do
 this. Perl numbers whose absolute values are integers under 2**31 (on


### PR DESCRIPTION
The text talks about "half-way-point alternation", which decides how to
round a number that is exactly half. There are several methods:
https://en.wikipedia.org/wiki/Rounding#Comparison_of_rounding_modes

That text was originally introduced in 1999, in commit
https://github.com/Perl/perl5/commit/65acb1b1d672587d3a0d073613a475584830e38e#diff-bd94515042a908ebbf4f9afefaa072a4

However, the example code does not show the rounding modes. Instead,
the weird rounded values happen because 0.05 cannot be represented
precisely in binary floating point. Look at this slightly modified
output of the same sample code:

    for (my $i = 0; $i < 1.01; $i += 0.05) { printf "%.1f %.20f\n", $i, $i }
    0.0 0.00000000000000000000
    0.1 0.05000000000000000278
    0.1 0.10000000000000000555
    0.2 0.15000000000000002220
    0.2 0.20000000000000001110
    0.2 0.25000000000000000000
    0.3 0.29999999999999998890
    0.3 0.34999999999999997780
    0.4 0.39999999999999996669
    0.4 0.44999999999999995559
    0.5 0.49999999999999994449
    0.5 0.54999999999999993339
    0.6 0.59999999999999997780
    0.7 0.65000000000000002220
    0.7 0.70000000000000006661
    0.8 0.75000000000000011102
    0.8 0.80000000000000015543
    0.9 0.85000000000000019984
    0.9 0.90000000000000024425
    1.0 0.95000000000000028866
    1.0 1.00000000000000022204

I'm fixing the sample code in this patch:

    for (my $i = -5; $i <= 5; $i += 0.5) { printf "% .0f % .20f\n", $i, $i }
    -5 -5.00000000000000000000
    -4 -4.50000000000000000000
    -4 -4.00000000000000000000
    -4 -3.50000000000000000000
    -3 -3.00000000000000000000
    -2 -2.50000000000000000000
    -2 -2.00000000000000000000
    -2 -1.50000000000000000000
    -1 -1.00000000000000000000
    -0 -0.50000000000000000000
     0  0.00000000000000000000
     0  0.50000000000000000000
     1  1.00000000000000000000
     2  1.50000000000000000000
     2  2.00000000000000000000
     2  2.50000000000000000000
     3  3.00000000000000000000
     4  3.50000000000000000000
     4  4.00000000000000000000
     4  4.50000000000000000000
     5  5.00000000000000000000

Which shows that `printf` will round to even on my machine. YMMV.