### PR TITLE
sco to mc

### DIFF
--- a/lib/perlfaq2.pod
+++ b/lib/perlfaq2.pod
@@ -81,8 +81,7 @@ contains tens of thousands of modules and extensions, source code
 and documentation, designed for I<everything> from commercial
 database interfaces to keyboard/screen control and running large web sites.
 
-You can search CPAN on L<http://metacpan.org> or
-L<http://search.cpan.org/>.
+You can search CPAN on L<http://metacpan.org>.
 
 The master web site for CPAN is L<http://www.cpan.org/>,
 L<http://www.cpan.org/SITES.html> lists all mirrors.

--- a/lib/perlfaq4.pod
+++ b/lib/perlfaq4.pod
@@ -2660,7 +2660,7 @@ The arrays.h/arrays.c code in the L<PGPLOT> module on CPAN does just this.
 If you're doing a lot of float or double processing, consider using
 the L<PDL> module from CPAN instead--it makes number-crunching easy.
 
-See L<http://search.cpan.org/dist/PGPLOT> for the code.
+See L<https://metacpan.org/release/PGPLOT> for the code.
 
 
 =head1 AUTHOR AND COPYRIGHT

--- a/lib/perlfaq8.pod
+++ b/lib/perlfaq8.pod
@@ -1102,7 +1102,7 @@ available drivers on CPAN: L<http://www.cpan.org/modules/by-module/DBD/> .
 You can read more about DBI on L<http://dbi.perl.org/> .
 
 Other modules provide more specific access: L<Win32::ODBC>, L<Alzabo>,
-C<iodbc>, and others found on CPAN Search: L<http://search.cpan.org/> .
+C<iodbc>, and others found on CPAN Search: L<https://metacpan.org/> .
 
 =head2 How do I make a system() exit on control-C?
 


### PR DESCRIPTION
As SCO is to be no more ( https://log.perl.org/2018/05/goodbye-search-dot-cpan-dot-org.html )