### PR TITLE
perlfaq9 - Updates to web framework listing

### DIFF
--- a/lib/perlfaq9.pod
+++ b/lib/perlfaq9.pod
@@ -38,20 +38,20 @@ Strongly object-oriented and fully-featured with a long development history and
 a large community and addon ecosystem. It is excellent for large and complex
 applications, where you have full control over the server.
 
-=item L<Dancer>
+=item L<Dancer2>
 
-Young and free of legacy weight, providing a lightweight and easy to learn API.
+Free of legacy weight, providing a lightweight and easy to learn API.
 Has a growing addon ecosystem. It is best used for smaller projects and
 very easy to learn for beginners.
 
 =item L<Mojolicious>
 
-Fairly young with a focus on HTML5 and real-time web technologies such as
-WebSockets.
+Self-contained and powerful for both small and larger projects,
+with a focus on HTML5 and real-time web technologies such as WebSockets.
 
 =item L<Web::Simple>
 
-Currently experimental, strongly object-oriented, built for speed and intended
+Strongly object-oriented and minimal, built for speed and intended
 as a toolkit for building micro web apps, custom frameworks or for tieing
 together existing Plack-compatible web applications with one central dispatcher.
 


### PR DESCRIPTION
Remove age descriptions of frameworks that aren't really relevant anymore, link to Dancer2 instead of Dancer, Web::Simple isn't experimental anymore, more description for Mojolicious.