### PR TITLE
Remove obsolete section in include path question

### DIFF
--- a/lib/perlfaq8.pod
+++ b/lib/perlfaq8.pod
@@ -1396,10 +1396,6 @@ environment variables, run-time switches, and in-code statements:
 
 =back
 
-The last is particularly useful because it knows about machine-dependent
-architectures. The C<lib.pm> pragmatic module was first
-included with the 5.002 release of Perl.
-
 =head2 Where are modules installed?
 
 Modules are installed on a case-by-case basis (as provided by the methods


### PR DESCRIPTION
"The last" was originally referring to the use of lib.pm, as the local::lib entry was added in https://github.com/Perl/perl5/commit/d12d61cff231dfdae5d1887a5c3905cbc67f0168 without changing the wording. It also isn't useful to include, since -I and PERL5LIB both correctly recognize arch and version directories as well. I also don't think there's value in continuing to mention that you need a slightly less ancient Perl for lib.pm, especially since it's dual life.