### PR TITLE
perlfaq2 and perlfaq3 - replace perlbug references with GitHub issue tracker

### DIFF
--- a/lib/perlfaq2.pod
+++ b/lib/perlfaq2.pod
@@ -209,10 +209,9 @@ First, ensure that you've found an actual bug. Second, ensure you've
 found an actual bug.
 
 If you've found a bug with the perl interpreter or one of the modules
-in the standard library (those that come with Perl), you can use the
-L<perlbug> utility that comes with Perl (>= 5.004). It collects
-information about your installation to include with your message, then
-sends the message to the right place.
+in the standard library (those that come with Perl), you can submit a
+bug report to the GitHub issue tracker at
+L<https://github.com/Perl/perl5/issues>.
 
 To determine if a module came with your version of Perl, you can
 install and use the L<Module::CoreList> module. It has the information

--- a/lib/perlfaq3.pod
+++ b/lib/perlfaq3.pod
@@ -1094,7 +1094,8 @@ XS support files.
 
 Download the ExtUtils::Embed kit from CPAN and run `make test'. If
 the tests pass, read the pods again and again and again. If they
-fail, see L<perlbug> and send a bug report with the output of
+fail, submit a bug report to L<https://github.com/Perl/perl5/issues>
+with the output of
 C<make test TEST_VERBOSE=1> along with C<perl -V>.
 
 =head2 When I tried to run my script, I got this message. What does it mean?


### PR DESCRIPTION
Update mentions to the more direct issue tracker.