### PR TITLE
Reference perldoc.perl.org instead of learn.perl.org for latest FAQ

### DIFF
--- a/inc/perlfaq.tt
+++ b/inc/perlfaq.tt
@@ -11,7 +11,7 @@ into nine major sections outlined in this document.
 =head2 Where to find the perlfaq
 
 The perlfaq is an evolving document.  Read the latest version at
-L<http://learn.perl.org/faq/>.  It is also included in the standard Perl
+L<https://perldoc.perl.org/perlfaq>.  It is also included in the standard Perl
 distribution.
 
 =head2 How to use the perlfaq
@@ -31,9 +31,8 @@ Review L<https://github.com/perl-doc-cats/perlfaq/wiki>.  If you don't find
 your suggestion create an issue or pull request against
 L<https://github.com/perl-doc-cats/perlfaq>.
 
-Once approved, changes are merged into L<https://github.com/tpf/perlfaq>, the
-repository which drives L<http://learn.perl.org/faq/>, and they are
-distributed with the next Perl 5 release.
+Once approved, changes will be distributed with the next Perl release and
+subsequently appear at L<https://perldoc.perl.org/perlfaq>.
 
 =head2 What if my question isn't answered in the FAQ?
 


### PR DESCRIPTION
https://learn.perl.org/faq/ now references perldoc.perl.org rather than being yet another manually updated copy of these docs, so cut out the middle man.