### PR TITLE
Require Dist::Zilla 6.014 for . in INC

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,7 +9,7 @@ author   = The Perl 5 Porters <perl5-porters@perl.org>
 license  = Perl_5
 copyright_holder = Tom Christiansen, Nathan Torkington, and others
 
-:version = 5.009    ; require Dist::Zilla 5 for proper encoding support
+:version = 6.014    ; . in @INC
 
 [AutoVersion]
 format = 5.{{ cldr('yyyyMMdd') . ($ENV{DEV} ? sprintf('_%03u', $ENV{DEV}) : '') }}


### PR DESCRIPTION
The `inc/` directory is no longer loaded as a lib dir since https://github.com/perl-doc-cats/perlfaq/commit/473fc79891c6bd03213a5380f88e06fc975fb466, but this relies on dzil behavior added in 6.012 and 6.014 to add . back to `@INC`.