### PR TITLE
Mention "trim" as a common name for removing space

### DIFF
--- a/lib/perlfaq4.pod
+++ b/lib/perlfaq4.pod
@@ -926,7 +926,7 @@ implementing it yourself is highly recommended; you'll save yourself odd bugs
 popping up later by just using code which has already been tried and tested in
 production for years.
 
-=head2 How do I strip blank space from the beginning/end of a string?
+=head2 How do I trim a string to strip blank space from the beginning/end?
 
 (contributed by brian d foy)
 


### PR DESCRIPTION
As discussed on perl5-porters, folks looking for this entry may not find
it if they are coming from another language where this is commonly
called "trim".

I didn't realize this was maintained in a separate repo, so this replaces the previous:
https://github.com/Perl/perl5/pull/18675