### PR TITLE
perlfaq5 - Remove suggestion to use read() for slurping

### DIFF
--- a/lib/perlfaq5.pod
+++ b/lib/perlfaq5.pod
@@ -1161,13 +1161,6 @@ You can also use a localized C<@ARGV> to eliminate the C<open>:
 
     my $var = do { local( @ARGV, $/ ) = $file; <> };
 
-For ordinary files you can also use the C<read> function.
-
-    read( $fh, $var, -s $fh );
-
-That third argument tests the byte size of the data on the C<$fh> filehandle
-and reads that many bytes into the buffer C<$var>.
-
 =head2 How can I read in a file by paragraphs?
 X<file, reading by paragraphs>
 


### PR DESCRIPTION
Due to issues mentioned in #96 and because readline is well-known and sufficient for this task.