### PR TITLE
Define “UTF-8 string” to refer to Perl-visible codepoints.

### DIFF
--- a/lib/perlglossary.pod
+++ b/lib/perlglossary.pod
@@ -3609,6 +3609,15 @@ characters with the General Category of Uppercase Letter, but any character
 with the Uppercase property, including some Letter Numbers and Symbols. Not
 to be confused with B<titlecase>.
 
+=item UTF-8 string
+
+A L</string> whose ordinals represent a valid sequence of UTF-8 bytes.
+Sometimes called a "UTF-8 encoded string".
+
+(B<IMPORTANT:> This is unrelated to Perl’s internal
+L<“UTF8 flag”|perlunifaq/What is "the UTF8 flag"?>, which only Perl itself
+should usually care about. UTF-8 strings may have that flag set or unset.)
+
 =back
 
 =head2 V


### PR DESCRIPTION
This is to address a recent p5p thread where disagreement over this term’s meaning seemed to play an outsized role.

I propose that the glossary define it explicitly as referring only to logical codepoints, irrespective of the underlying “UTF8” flag.