### PR TITLE
Make clear Perl 5 is Raku's older sibling, not Perl 4's.

### DIFF
--- a/lib/perlfaq1.pod
+++ b/lib/perlfaq1.pod
@@ -122,8 +122,8 @@ current stable release of Perl.
 =head2 What are Perl 4, Perl 5, or Raku (Perl 6)?
 
 In short, Perl 4 is the parent to both Perl 5 and Raku (formerly known as
-Perl 6). Perl 5 is the older sibling, and though they are different languages,
-someone who knows one will spot many similarities in the other.
+Perl 6). Perl 5 is Raku's older sibling, and though they are different
+languages, someone who knows one will spot many similarities in the other.
 
 The number after Perl (i.e. the 5 after Perl 5) is the major release
 of the perl interpreter as well as the version of the language. Each

--- a/lib/perlfaq1.pod
+++ b/lib/perlfaq1.pod
@@ -119,28 +119,6 @@ current stable release of Perl.
 
 =back
 
-=head2 What are Perl 4, Perl 5, or Raku (Perl 6)?
-
-In short, Perl 4 is the parent to both Perl 5 and Raku (formerly known as
-Perl 6). Perl 5 is Raku's older sibling, and though they are different
-languages, someone who knows one will spot many similarities in the other.
-
-The number after Perl (i.e. the 5 after Perl 5) is the major release
-of the perl interpreter as well as the version of the language. Each
-major version has significant differences that earlier versions cannot
-support.
-
-The current major release of Perl is Perl 5, first released in
-1994. It can run scripts from the previous major release, Perl 4
-(March 1991), but has significant differences.
-
-Raku is a reinvention of Perl, a language in the same lineage but
-not compatible. The two are complementary, not mutually exclusive. Raku is
-not meant to replace Perl, and vice versa. See L</"What is Raku (Perl 6)?">
-below to find out more.
-
-See L<perlhist> for a history of Perl revisions.
-
 =head2 What is Raku (Perl 6)?
 
 Raku (formerly known as Perl 6) was I<originally> described as the community's


### PR DESCRIPTION
The previous sentence was slightly ambiguous (is Perl 5 the older sibling of Perl 4, Raku, or both?). This clarifies that.