### PR TITLE
Fix typos in perlfaq 1 to 4

### DIFF
--- a/lib/perlfaq1.pod
+++ b/lib/perlfaq1.pod
@@ -212,7 +212,7 @@ and L<community|http://www.perl.org/community.html> which surrounds it.
 For comparisons to a specific language it is often best to create
 a small project in both languages and compare the results, make sure
 to use all the L<resources|http://www.cpan.org/> of each language,
-as a language is far more than just it's syntax.
+as a language is far more than just its syntax.
 
 =head2 Can I do [task] in Perl?
 

--- a/lib/perlfaq2.pod
+++ b/lib/perlfaq2.pod
@@ -23,7 +23,7 @@ all known and current Unix derivatives are supported (perl's native
 platform), as are other systems like VMS, DOS, OS/2, Windows,
 QNX, BeOS, OS X, MPE/iX and the Amiga.
 
-Binary distributions for some proprietary platforms can be found
+Binary distributions for some proprietary platforms can be found in the
 L<http://www.cpan.org/ports/> directory. Because these are not part of
 the standard distribution, they may and in fact do differ from the
 base perl port in a variety of ways. You'll have to check their
@@ -248,7 +248,7 @@ Use the directions you find.
 Sometimes the module author does not declare a bugtracker. For a long
 time, everyone assumed that the CPAN Request Tracker
 (L<https://rt.cpan.org>) was the bugtracker since every distribution had
-an RT queue generated automatically. In somes cases, the author might
+an RT queue generated automatically. In some cases, the author might
 use CPAN RT. They also might have not declared a different
 bugtracker but don't use CPAN RT.
 

--- a/lib/perlfaq3.pod
+++ b/lib/perlfaq3.pod
@@ -99,7 +99,7 @@ Have you read the appropriate manpages? Here's a brief index:
 
 =item L<perlre> - Perl regular expressions
 
-=item L<perlfunc> - Perl builtin functions>
+=item L<perlfunc> - Perl builtin functions
 
 =item L<perlop> - Perl operators and precedence
 
@@ -173,7 +173,7 @@ that C<CPAN.pm> understands and can use to re-install every module:
     $ cpan -a
 
 Inside a Perl program, you can use the L<ExtUtils::Installed> module to
-show all installed distributions, although it can take awhile to do
+show all installed distributions, although it can take a while to do
 its magic. The standard library which comes with Perl just shows up
 as "Perl" (although you can get those with L<Module::CoreList>).
 
@@ -362,12 +362,12 @@ L<http://e-p-i-c.sf.net/>
 The Eclipse Perl Integration Project integrates Perl
 editing/debugging with Eclipse.
 
-=item Enginsite
+=item EngInSite
 
 L<http://www.enginsite.com/>
 
 Perl Editor by EngInSite is a complete integrated development
-environment (IDE) for creating, testing, and  debugging  Perl scripts;
+environment (IDE) for creating, testing, and debugging Perl scripts;
 the tool runs on Windows 9x/NT/2000/XP or later.
 
 =item IntelliJ IDEA

--- a/lib/perlfaq4.pod
+++ b/lib/perlfaq4.pod
@@ -70,7 +70,7 @@ are in base 10:
     print $string + 44; # prints 688, certainly not octal!
 
 This problem usually involves one of the Perl built-ins that has the
-same name a Unix command that uses octal numbers as arguments on the
+same name as a Unix command that uses octal numbers as arguments on the
 command line. In this example, C<chmod> on the command line knows that
 its first argument is octal because that's what it does:
 
@@ -313,10 +313,10 @@ it might never use as a number. In that case, string semantics wins. But,
 if there is a numeric value already, numeric semantics win. Force perl
 to compute the numeric value by adding 0:
 
-    my($i, $j) = ("11", "3"); $j += 0  # $i & $j  # "11"  &  3 -> 3
+    my($i, $j) = ("11", "3"); $j += 0;  # $i & $j  # "11"  &  3 -> 3
 
 However, this is not a documented feature, or as L<perlop> says, it "is not
-well defined". One way to fix ensure numeric semantics is to explicitly
+well defined". One way to ensure numeric semantics is to explicitly
 convert both of values to numbers:
 
 	(0+$i) & (0+$j)
@@ -405,7 +405,7 @@ course, living in a state of sin."
 
 Perl relies on the underlying system for the implementation of
 C<rand> and C<srand>; on some systems, the generated numbers are
-not random enough (especially on Windows : see
+not random enough (especially on Windows: see
 L<http://www.perlmonks.org/?node_id=803632>).
 Several CPAN modules in the C<Math> namespace implement better
 pseudorandom generators; see for example
@@ -580,7 +580,7 @@ X<timelocal>
 
 To do it correctly, you can use one of the C<Date> modules since they
 work with calendars instead of times. The L<DateTime> module makes it
-simple, and give you the same time of day, only the day before,
+simple, and gives you the same time of day, only the day before,
 despite daylight saving time changes:
 
     use DateTime;
@@ -898,7 +898,7 @@ for you:
 			autoformat($s, { case => $style }) =~ s/\R+\z//r;
     }
 
-Each style has a different idea of what if should do with small words:
+Each style has a different idea of what it should do with small words:
 
 	original:  Going to the desert with a camel
 	sentence:  Going to the desert with a camel
@@ -1196,7 +1196,7 @@ When you want a list to be expanded per C<$">, use C<@{[ ... ]}>.
     my $scalar = 'STRING';
     my @array = ( 'zorro', 'a', 1, 'B', 3 );
 
-    # Print the current date and time and then Tommorrow
+    # Print the current date and time and then Tomorrow
     my $t = Time::Piece->new;
     say "Now is: ${\ $t->cdate() }";
     say "Tomorrow: ${\ do{ my $T=Time::Piece->new + ONE_DAY ; $T->fullday }}";
@@ -1536,7 +1536,7 @@ array. This kind of an array will take up less space:
     my @primes = (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31);
     my @is_tiny_prime = ();
     for (@primes) { $is_tiny_prime[$_] = 1 }
-    # or simply  @istiny_prime[@primes] = (1) x @primes;
+    # or simply  @is_tiny_prime[@primes] = (1) x @primes;
 
 Now you check whether $is_tiny_prime[$some_number].
 
@@ -1639,7 +1639,7 @@ two different answers:
     cmpStrHard(\%a, \%b) == 0 ? "the same" : "different";
 
 
-The first reports that both those the hashes contain the same data,
+The first reports that both hashes contain the same data,
 while the second reports that they do not. Which you prefer is left as
 an exercise to the reader.
 
@@ -2088,7 +2088,7 @@ all of the keys of the hash and gives them back to you as a list. You
 can then get the value through the particular key you're processing:
 
     foreach my $key ( keys %hash ) {
-        my $value = $hash{$key}
+        my $value = $hash{$key};
         ...
     }
 
@@ -2097,7 +2097,7 @@ process the hash elements. For instance, you can sort the keys so you
 can process them in lexical order:
 
     foreach my $key ( sort keys %hash ) {
-        my $value = $hash{$key}
+        my $value = $hash{$key};
         ...
     }
 
@@ -2106,7 +2106,7 @@ to deal with the keys that start with C<text:>, you can select just
 those using C<grep>:
 
     foreach my $key ( grep /^text:/, keys %hash ) {
-        my $value = $hash{$key}
+        my $value = $hash{$key};
         ...
     }
 
@@ -2140,7 +2140,7 @@ the original hashes as they were.
 
 If you want to preserve the original hashes, copy one hash (C<%hash1>)
 to a new hash (C<%new_hash>), then add the keys from the other hash
-(C<%hash2> to the new hash. Checking that the key already exists in
+(C<%hash2>) to the new hash. Checking that the key already exists in
 C<%new_hash> gives you a chance to decide what to do with the
 duplicates:
 
@@ -2525,7 +2525,7 @@ back the reference from the stringified form, at least without doing
 some extra work on your own.
 
 Remember that the entry in the hash will still be there even if
-the referenced variable  goes out of scope, and that it is entirely
+the referenced variable goes out of scope, and that it is entirely
 possible for Perl to subsequently allocate a different variable at
 the same address. This will mean a new variable might accidentally
 be associated with the value for an old.


### PR DESCRIPTION
This PR contains straightforward typos fixes that should not affect the intended meaning of the sentences.