### PR TITLE
perlfaq5.pod: fix syscall example

### DIFF
--- a/lib/perlfaq5.pod
+++ b/lib/perlfaq5.pod
@@ -1399,7 +1399,7 @@ to, you may be able to do this:
 
     require './sys/syscall.ph';
     my $rc = syscall(SYS_close(), $fd + 0);  # must force numeric
-    die "can't sysclose $fd: $!" unless $rc == -1;
+    die "can't sysclose $fd: $!" if $rc == -1;
 
 Or, just use the fdopen(3S) feature of C<open()>:
 


### PR DESCRIPTION
The check seems to be inverted since the given syscall() returns -1 upon failure, not success.