### PR TITLE
perlfaq6.pod: fix a typo

### DIFF
--- a/lib/perlfaq6.pod
+++ b/lib/perlfaq6.pod
@@ -401,7 +401,7 @@ need the C</o>.
 You can watch Perl's regular expression engine at work to verify for
 yourself if Perl is recompiling a regular expression. The C<use re
 'debug'> pragma (comes with Perl 5.005 and later) shows the details.
-With Perls before 5.6, you should see C<re> reporting that its
+With Perls before 5.6, you should see C<re> reporting that it's
 compiling the regular expression on each iteration. With Perl 5.6 or
 later, you should only see C<re> report that for the first iteration.
 


### PR DESCRIPTION
This seems to be the last one from the bunch.