### PR TITLE
Detabify perlfaq

### DIFF
--- a/lib/perlfaq2.pod
+++ b/lib/perlfaq2.pod
@@ -225,13 +225,13 @@ To determine if a module came with your version of Perl, you can
 install and use L<Module::CoreList>. It knows the modules (with their
 versions) included with each release of Perl:
 
-	$ corelist File::Copy
-	Data for 2023-07-02
-	File::Copy was first released with perl 5.002
+    $ corelist File::Copy
+    Data for 2023-07-02
+    File::Copy was first released with perl 5.002
 
-	$ corelist Business::ISBN
-	Data for 2023-07-02
-	Business::ISBN was not in CORE (or so I think)
+    $ corelist Business::ISBN
+    Data for 2023-07-02
+    Business::ISBN was not in CORE (or so I think)
 
 If the module does not come with Perl, report its issues
 using the tool that the particular module author decided to use, such as

--- a/lib/perlfaq4.pod
+++ b/lib/perlfaq4.pod
@@ -293,17 +293,17 @@ bitvector 0b0011_0011.
 These operations have different results even though you might think they
 look like the same "number":
 
-	 11  &  3;   # 0b0000_1011 & 0b0000_0011
-	             #     -> 0b0000_0011   (number 3)
-	"11" & "3";  # 0b0011_0001_0011_0001 & 0b0011_0011
-	             #     -> 0b0011_0001   (ASCII char "1")
+     11  &  3;   # 0b0000_1011 & 0b0000_0011
+                 #     -> 0b0000_0011   (number 3)
+    "11" & "3";  # 0b0011_0001_0011_0001 & 0b0011_0011
+                 #     -> 0b0011_0001   (ASCII char "1")
 
 Note that if any operand has a numeric value, perl uses numeric
 semantics (although you should not count on this):
 
-	my($i, $j) = ( 11,   3 );   # $i & $j  # 11  &  3 -> 3
- 	my($i, $j) = ("11",  3 );   # $i & $j  # 11  &  3 -> 3
- 	my($i, $j) = ("11", "3");   # $i & $j  # "11"  &  "3" -> 1
+    my($i, $j) = ( 11,   3 );   # $i & $j  # 11  &  3 -> 3
+    my($i, $j) = ("11",  3 );   # $i & $j  # 11  &  3 -> 3
+    my($i, $j) = ("11", "3");   # $i & $j  # "11"  &  "3" -> 1
 
 Remember that a perl scalar can have both string and numeric values at
 the same time. A value that starts as a string and has never encountered
@@ -319,7 +319,7 @@ However, this is not a documented feature, or as L<perlop> says, it "is not
 well defined". One way to ensure numeric semantics is to explicitly
 convert both of values to numbers:
 
-	(0+$i) & (0+$j)
+    (0+$i) & (0+$j)
 
 To fix this annoyance, Perl v5.22 separated the string and number
 behavior. The C<bitwise> feature introduced four new operators that
@@ -329,11 +329,11 @@ only numeric semantics.
 
 Enable this feature explicitly with L<feature>:
 
-	use feature qw(bitwise);
+    use feature qw(bitwise);
 
 Or, as of v5.28, require the minimum version of perl with C<use>:
 
-	use v5.28;  # bitwise feature for free
+    use v5.28;  # bitwise feature for free
 
 =head2 How do I multiply matrices?
 
@@ -893,25 +893,25 @@ for you:
 
     printf "%-10s %s\n", "original:", $s;
     for my $style (qw( sentence title highlight )) {
-    	printf "%-10s %s\n",
-        	"$style:",
-			autoformat($s, { case => $style }) =~ s/\R+\z//r;
+        printf "%-10s %s\n",
+            "$style:",
+            autoformat($s, { case => $style }) =~ s/\R+\z//r;
     }
 
 Each style has a different idea of what it should do with small words:
 
-	original:  Going to the desert with a camel
-	sentence:  Going to the desert with a camel
-	title:     Going To The Desert With A Camel
-	highlight: Going to the Desert with a Camel
+    original:  Going to the desert with a camel
+    sentence:  Going to the desert with a camel
+    title:     Going To The Desert With A Camel
+    highlight: Going to the Desert with a Camel
 
 Trying this yourself in a simple regex has more than a few pitfalls.
 Perl "words" are groups of C<\w+>, but that's not what you want to
 capitalize. Some of those characters aren't even letters. What if you
 used a word boundary, C<\b>?
 
-	my $string = "A camel's journey";
-	$string =~ s/\b(\w)/\U$1/g;  # A Camel'S Journey
+    my $string = "A camel's journey";
+    $string =~ s/\b(\w)/\U$1/g;  # A Camel'S Journey
 
 How is Perl supposed to know not to capitalize that C<s>? You could work
 harder to look for preceding whitespace or the beginning of the string:
@@ -928,9 +928,9 @@ Unicode word and sentence boundaries to fix this sort of problem. The
 C<\b{wb}> word boundary ignores some things that it doesn't think start
 or end "human" words:
 
-	use v5.22;
-	my $string = "A camel's journey";
-	$string =~ s/\b{wb}(\w)/\U$1/g;  # A Camel's Journey
+    use v5.22;
+    my $string = "A camel's journey";
+    $string =~ s/\b{wb}(\w)/\U$1/g;  # A Camel's Journey
 
 The details are in Unicode Technical Report #29
 (L<https://unicode.org/reports/tr29/>), and you should make sure that


### PR DESCRIPTION
There were a few instances of tabs intermixed with the regular spaces. I assumed that each tab was intended to fill up to 4 spaces.