### PR TITLE
Fix some of the broken links

### DIFF
--- a/lib/perlfaq3.pod
+++ b/lib/perlfaq3.pod
@@ -296,8 +296,8 @@ or I<Mastering Perl>, chapter 5.
 L<perldebguts> documents creating a custom debugger if you need to
 create a special sort of profiler. brian d foy describes the process
 in I<The Perl Journal>, "Creating a Perl Debugger",
-L<http://www.ddj.com/184404522> , and "Profiling in Perl"
-L<http://www.ddj.com/184404580> .
+L<https://drdobbs.com/creating-a-perl-debugger/184404522> , and
+"Profiling in Perl" L<https://drdobbs.com/profiling-in-perl/184404580> .
 
 Perl.com has two interesting articles on profiling: "Profiling Perl",
 by Simon Cozens, L<https://www.perl.com/pub/2004/06/25/profiling.html/>
@@ -406,7 +406,7 @@ under Windows 95/98/NT/2000.
 
 =item OptiPerl
 
-L<http://www.optiperl.com/>
+L<https://www.uptiv.com/free/optiperl/>
 
 OptiPerl is a Windows IDE with simulated CGI environment, including
 debugger and syntax-highlighting editor.
@@ -575,7 +575,7 @@ Note that the perl-mode of emacs will have fits with C<"main'foo">
 are probably using C<"main::foo"> in new Perl code anyway, so this
 shouldn't be an issue.
 
-For CPerlMode, see L<http://www.emacswiki.org/cgi-bin/wiki/CPerlMode>
+For CPerlMode, see L<https://www.emacswiki.org/emacs/CPerlMode>
 
 =head2 How can I use curses with Perl?
 

--- a/lib/perlfaq4.pod
+++ b/lib/perlfaq4.pod
@@ -505,7 +505,7 @@ millennium.
 You could just store all your dates as a number and then subtract.
 Life isn't always that simple though.
 
-The L<Time::Piece> module, which comes with Perl, replaces L<localtime>
+The L<Time::Piece> module, which comes with Perl, replaces C<localtime>
 with a version that returns an object. It also overloads the comparison
 operators so you can compare them directly:
 

--- a/lib/perlfaq5.pod
+++ b/lib/perlfaq5.pod
@@ -734,8 +734,7 @@ commas:
 L<CLDR::Number> has many more advanced features to handle just about
 anything that you might want. Olaf Alders' article "Stop Writing Your Own
 Commify Functions" has more examples
-(L<https://www.olafalders.com/2015/09/04/stop-writing-your-own-commify-
-functions/>).
+(L<https://www.olafalders.com/2015/09/04/stop-writing-your-own-commify-functions/>).
 
 If you know exactly what you want, a simple subroutine might suffice.
 This example will add separators to your number between groups of three
@@ -1117,7 +1116,7 @@ the filesystems, not of utime().
 X<print, to multiple files>
 
 To connect one filehandle to several output filehandles,
-you can use the L<IO::Tee> or L<Tie::FileHandle::Multiplex> modules.
+you can use the L<IO::Tee> or L<Tie::FileHandle::MultiPlex> modules.
 
 If you only have to do this once, you can print individually
 to each filehandle.


### PR DESCRIPTION
This partially addresses issue #84.

Also, is there any automatic folding procedures in place? The olafalders link in perlfaq5 was probably originally malformed by trying to fit the URL inside 80 symbols. 