### PR TITLE
Remove mention of TCP::Client

### DIFF
--- a/lib/perlfaq8.pod
+++ b/lib/perlfaq8.pod
@@ -915,8 +915,7 @@ causes many inefficiencies.
 
 =head2 Can I use perl to run a telnet or ftp session?
 
-Try the L<Net::FTP>, L<TCP::Client>, and L<Net::Telnet> modules
-(available from CPAN).
+Try the L<Net::FTP> and L<Net::Telnet> modules (available from CPAN).
 L<http://www.cpan.org/scripts/netstuff/telnet.emul.shar> will also help
 for emulating the telnet protocol, but L<Net::Telnet> is quite
 probably easier to use.


### PR DESCRIPTION
Unlike links to the other two modules mentioned in the same sentence, link to TCP::Client does not properly resolve and the module is hard to locate in general (see comments under issue #84 for more details). The module is not used in any of the provided usage examples.