### PR TITLE
perlfaq5 - fix link markup

### DIFF
--- a/lib/perlfaq5.pod
+++ b/lib/perlfaq5.pod
@@ -734,8 +734,7 @@ commas:
 L<CLDR::Number> has many more advanced features to handle just about
 anything that you might want. Olaf Alders' article "Stop Writing Your Own
 Commify Functions" has more examples
-(L<https://www.olafalders.com/2015/09/04/stop-writing-your-own-commify-
-functions/>).
+(L<https://www.olafalders.com/2015/09/04/stop-writing-your-own-commify-functions/>).
 
 If you know exactly what you want, a simple subroutine might suffice.
 This example will add separators to your number between groups of three


### PR DESCRIPTION
The newline breaks the link and causes this to render to `("/www.olafalders.com/2015/09/04/stop-writing-your-own-commify- functions/" in https:)`, which is definitely not the intended link target.